### PR TITLE
Refactor: Remove DOMO functionality from follow/follower lists

### DIFF
--- a/yamap_auto/config.yaml
+++ b/yamap_auto/config.yaml
@@ -7,9 +7,9 @@ domo_settings:
   short_wait_sec: 2                    # スクリプト内で使用する短い追加の待機時間 (秒) - 主にページ描画の安定化のため
   delay_after_domo_action_sec: 1.5     # DOMO操作（クリック）後の共通待機時間 (秒) - サーバー負荷軽減と確実な処理のため
 
-  domo_followed_users_posts: true      # true: フォロー中のユーザーの最新投稿へDOMOする機能を有効にする
-  max_followed_users_to_process: 10    #   上記機能で一度にDOMO処理をする最大ユーザー数 (フォロー中リストの上から順)
-  delay_between_users_sec: 3           #   上記機能で各ユーザーのDOMO処理後に次のユーザーへ移るまでの待機時間 (秒)
+  # domo_followed_users_posts: true      # true: フォロー中のユーザーの最新投稿へDOMOする機能を有効にする (機能削除済み)
+  # max_followed_users_to_process: 10    #   上記機能で一度にDOMO処理をする最大ユーザー数 (フォロー中リストの上から順) (機能削除済み)
+  # delay_between_users_sec: 3           #   上記機能で各ユーザーのDOMO処理後に次のユーザーへ移るまでの待機時間 (秒) (機能削除済み)
 
   domo_users_who_domoed_my_posts: true # true: 自身の投稿にDOMOしてくれたユーザーの最新投稿へDOMOする機能を有効にする
   max_my_activities_to_check_domo: 5   #   上記機能でDOMOユーザーを確認する自身の活動日記の最大数 (最新の日記から順に)


### PR DESCRIPTION
This change removes the feature that automatically DOMOs the latest posts of users in the 'following' list.

- Deleted the `domo_followed_users_latest_posts` function.
- Deleted the `get_followed_users_profiles` function as it was only used by the above.
- Removed the call to this function in the main script execution block.
- Commented out related configuration options in `config.yaml` (`domo_followed_users_posts`, `max_followed_users_to_process`, `delay_between_users_sec`).

This is part of an effort to consolidate DOMO actions, focusing them on timeline-based interactions rather than iterating through follow lists.