### PR TITLE
Fix: プロフィールページ遷移後の待機処理を大幅に強化

### DIFF
--- a/yamap_auto/config.yaml
+++ b/yamap_auto/config.yaml
@@ -54,7 +54,7 @@ search_and_follow_settings:
   max_pages_to_process_search: 3       # 検索結果を処理する最大ページ数
   max_users_to_process_per_page: 5     # 検索結果1ページあたりで処理する最大ユーザー数（活動記録数）
   min_followers_for_search_follow: 20  # フォロー対象とするユーザーの最低フォロワー数
-  follow_ratio_threshold_for_search: 0.9 # フォロー対象とするユーザーの「フォロー数/フォロワー数」の閾値 (この値未満のユーザーをフォロー)
+  follow_ratio_threshold_for_search: 0.9 # フォロー対象とするユーザーの「フォロー数/フォロワー数」の閾値 (この値以上のユーザーをフォロー)
   domo_latest_activity_after_follow: true # フォロー後に最新の活動記録へDOMOするかのフラグ
   delay_between_user_processing_in_search_sec: 5.0 # 検索結果でのユーザー処理間の待機時間 (秒)
   delay_after_pagination_sec: 3.0      # 検索結果のページネーション後の待機時間 (秒)


### PR DESCRIPTION
- search_follow_and_domo_users関数で、プロフィールページ遷移後、 URL、ユーザー名、readyState、フッター要素の複合条件で待機するよう修正。
- find_follow_button_on_profile_page関数内の冗長な初期待機を削除。
- find_follow_button_on_profile_page関数冒頭にURLとタイトルのログ出力を追加。