### PR TITLE
Docs: Update README and TASK_MANAGEMENT for yamap_auto_domo.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Selenium WebDriverを使用してブラウザを操作し、設定ファイル (
         *   その他、詳細は `config.yaml` を参照。
     *   `follow_back_settings`: フォローバック機能に関する設定。
         *   `enable_follow_back`: 機能の有効/無効 (true/false)
-        *   `max_users_to_follow_back`: 一度にフォローバックする最大ユーザー数
+        *   `max_users_to_follow_back`: 一度にフォローバックする最大ユーザー数 (全ページを通じての合計)
+        *   `max_pages_for_follow_back`: フォローバック確認のためにチェックするフォロワーリストの最大ページ数
     *   `timeline_domo_settings`: タイムライン上の活動記録へのDOMO機能に関する設定。
         *   `enable_timeline_domo`: 機能の有効/無効 (true/false)
         *   `max_activities_to_domo_on_timeline`: DOMOする最大の活動記録数

--- a/TASK_MANAGEMENT.md
+++ b/TASK_MANAGEMENT.md
@@ -86,7 +86,7 @@
     *   [x] `config.yaml` から設定値を読み込み、動作を制御 - 実装済み
 *   [ ] エラーハンドリング、ログ出力の強化 - 継続的に改善要
 *   [x] main関数での各機能の呼び出し制御 - 実装済み
-*   [x] README.md の更新 (新機能の追加、config.yaml の説明更新など) - 今回対応済 (コミットハッシュ: `[NEEDS_ACTUAL_COMMIT_HASH_AFTER_MERGE]`)
+*   [x] README.md の更新 (新機能の追加、config.yaml の説明更新、旧スクリプト記述削除) - 今回対応済 (コミットハッシュ: `[NEEDS_ACTUAL_COMMIT_HASH_AFTER_MERGE]`)
 *   [ ] 動作確認・デバッグ - 継続的に必要
 
 **その他:**


### PR DESCRIPTION
- Updated README.md to include `max_pages_for_follow_back` in `follow_back_settings` and ensure descriptions align with new features.
- Standardized the README update task description within TASK_MANAGEMENT.md for consistency.
- Both files reflect the completion of documenting recent enhancements to `yamap_auto_domo.py`.