### PR TITLE
refactor: DOMO及びフォロー関連処理をユーティリティモジュールに分割

### DIFF
--- a/TASK_MANAGEMENT.md
+++ b/TASK_MANAGEMENT.md
@@ -7,8 +7,8 @@
 ## 🛠 仕掛中タスク
 
 *   [x] `yamap_auto_domo.py` のリファクタリング - 機能分割 (ログイン関連処理を `driver_utils.py` に分割完了) `[PREVIOUS_COMMIT_HASH_PLACEHOLDER]`
-*   [x] `yamap_auto_domo.py` のリファクタリング - 機能分割 (ユーザープロフィール関連処理を `user_profile_utils.py` に分割完了: `get_latest_activity_url`, `get_user_follow_counts`, `find_follow_button_on_profile_page`) `[THIS_COMMIT_HASH]`
-*   [ ] `yamap_auto_domo.py` のリファクタリング - 機能分割 (継続)
+*   [x] `yamap_auto_domo.py` のリファクタリング - 機能分割 (ユーザープロフィール関連処理を `user_profile_utils.py` に分割完了: `get_latest_activity_url`, `get_user_follow_counts`, `find_follow_button_on_profile_page`) `[PREVIOUS_COMMIT_HASH_PLACEHOLDER]`
+*   [ ] `yamap_auto_domo.py` のリファクタリング - 機能分割 (継続: DOMO関連処理を `domo_utils.py` に、リストアイテムからのフォロー関連処理を `follow_utils.py` に分割) `[THIS_COMMIT_HASH]`
 *   [ ] エラーハンドリング、ログ出力の強化 - 継続的に改善要
 *   [ ] 動作確認・デバッグ - 継続的に必要
 
@@ -28,6 +28,9 @@
     *   [ ] 検索＆フォロー機能への並列処理の導入検討（アカウントの安全性とYAMAPの規約を考慮）
     *   [ ] 検索＆フォロー機能におけるアクションのバッチ処理検討（YAMAPの規約範囲内）
 *   これらのスクリプトを管理しやすいよう分割するリファクタリング
+    *   [ ] `yamap_auto_domo.py` 内のタイムライン処理 (`domo_timeline_activities`, `domo_timeline_activities_parallel`) を `timeline_utils.py` 等に分割
+    *   [ ] `yamap_auto_domo.py` 内の検索結果処理 (`search_follow_and_domo_users`) を `search_utils.py` 等に分割
+    *   [ ] `yamap_auto_domo.py` 内のフォローバック処理 (`follow_back_users_new`) を `follow_back_utils.py` 等に分割
 (ここにメモや改善案を記述)
 
 ---

--- a/yamap_auto/domo_utils.py
+++ b/yamap_auto/domo_utils.py
@@ -1,0 +1,141 @@
+# coding: utf-8
+"""
+YAMAP DOMO関連ユーティリティ関数群
+"""
+import time
+import logging
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException, NoSuchElementException
+
+# driver_utilsから設定情報を取得するためのインポート (直接configを読むのではなく、メインスクリプトから渡す設計も考慮)
+# 現状は yamap_auto_domo.py と同様に直接 main_config を参照する形を一旦取る
+from .driver_utils import get_main_config # main_config を取得するため
+
+logger = logging.getLogger(__name__) # このモジュール用のロガーを取得
+
+# --- グローバル定数 (必要に応じてメインスクリプトから渡すか、ここで定義) ---
+# BASE_URL は driver_utils からインポートするか、メインスクリプトから渡す方が望ましい
+# ここでは一旦、メインスクリプト側で定義されているものを利用する想定
+# from .driver_utils import BASE_URL # driver_utils にあるならこちらが良い
+
+# --- 設定情報の読み込み ---
+# main_config はこのモジュールがロードされた時点で driver_utils 経由で読み込まれる想定
+# ただし、循環参照や初期化順序に注意が必要。
+# 安全策としては、関数呼び出し時に main_config を引数として渡す方が良い。
+# ここでは、yamap_auto_domo.py の既存実装に合わせて、グローバルに main_config を参照する。
+try:
+    main_config = get_main_config()
+    if not main_config:
+        logger.error("domo_utils: main_config の読み込みに失敗しました。")
+        # ここでエラーを発生させるか、デフォルト設定でフォールバックするかは設計次第
+        main_config = {} # 空の辞書でフォールバック (エラーを回避するため)
+except Exception as e:
+    logger.error(f"domo_utils: 設定情報 (main_config) の読み込み中にエラー: {e}", exc_info=True)
+    main_config = {}
+
+
+def domo_activity(driver, activity_url, base_url="https://yamap.com"):
+    """
+    指定された活動日記URLのページを開き、DOMOボタンを探してクリックします。
+    既にDOMO済みの場合は実行しません。
+
+    Args:
+        driver (webdriver.Chrome): Selenium WebDriverインスタンス。
+        activity_url (str): DOMO対象の活動日記の完全なURL。
+        base_url (str): YAMAPのベースURL。
+
+    Returns:
+        bool: DOMOに成功した場合はTrue。既にDOMO済み、ボタンが見つからない、
+              またはエラーが発生した場合はFalse。
+    """
+    activity_id_for_log = activity_url.split('/')[-1] # ログ用に活動日記ID部分を抽出
+    logger.info(f"活動日記 ({activity_id_for_log}) へDOMOを試みます。")
+    try:
+        # 1. 対象の活動日記ページへ遷移 (既にそのページにいなければ)
+        current_page_url = driver.current_url
+        if current_page_url != activity_url:
+            logger.debug(f"対象の活動日記ページ ({activity_url}) に遷移します。")
+            driver.get(activity_url)
+            # URLが正しく遷移したことを確認 (活動日記IDが含まれるかで判断)
+            WebDriverWait(driver, 15).until(EC.url_contains(activity_id_for_log))
+        else:
+            logger.debug(f"既に活動日記ページ ({activity_url}) にいます。")
+
+        # 2. DOMOボタンの探索
+        primary_domo_button_selector = "button[data-testid='ActivityDomoButton']"
+        id_domo_button_selector = "button#DomoActionButton"
+
+        domo_button = None
+        current_selector_used = ""
+
+        for idx, selector in enumerate([primary_domo_button_selector, id_domo_button_selector]):
+            try:
+                logger.debug(f"DOMOボタン探索試行 (セレクタ: {selector})")
+                wait_time = 5 if idx == 0 else 2
+                domo_button_candidate = WebDriverWait(driver, wait_time).until(
+                    EC.element_to_be_clickable((By.CSS_SELECTOR, selector))
+                )
+                if domo_button_candidate:
+                    domo_button = domo_button_candidate
+                    current_selector_used = selector
+                    logger.debug(f"DOMOボタンを発見 (セレクタ: '{selector}')")
+                    break
+            except TimeoutException:
+                logger.debug(f"DOMOボタンがセレクタ '{selector}' で見つからず、またはタイムアウトしました。")
+                continue
+
+        if not domo_button:
+            logger.warning(f"DOMOボタンが見つかりませんでした: {activity_id_for_log}")
+            return False
+
+        # 3. DOMO済みかどうかの判定
+        aria_label_before = domo_button.get_attribute("aria-label")
+        is_domoed = False
+
+        if aria_label_before and ("Domo済み" in aria_label_before or "domoed" in aria_label_before.lower() or "ドモ済み" in aria_label_before):
+            is_domoed = True
+            logger.info(f"既にDOMO済みです (aria-label='{aria_label_before}'): {activity_id_for_log}")
+        else:
+            try:
+                icon_span = domo_button.find_element(By.CSS_SELECTOR, "span[class*='DomoActionContainer__DomoIcon'], span.RidgeIcon")
+                if "is-active" in icon_span.get_attribute("class"):
+                    is_domoed = True
+                    logger.info(f"既にDOMO済みです (アイコン is-active 確認): {activity_id_for_log}")
+            except NoSuchElementException:
+                logger.debug("DOMOボタン内のis-activeアイコンspanが見つかりませんでした。aria-labelに依存します。")
+
+        # 4. DOMO実行 (まだDOMOしていなければ)
+        if not is_domoed:
+            logger.info(f"DOMOを実行します: {activity_id_for_log} (使用ボタンセレクタ: '{current_selector_used}')")
+            driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", domo_button)
+            time.sleep(0.1)
+            domo_button.click()
+
+            action_delays = main_config.get("action_delays", {})
+            delay_after_action = action_delays.get("after_domo_sec", 1.5)
+
+            try:
+                WebDriverWait(driver, 5).until(
+                    lambda d: ("Domo済み" in (d.find_element(By.CSS_SELECTOR, current_selector_used).get_attribute("aria-label") or "")) or \
+                              ("is-active" in (d.find_element(By.CSS_SELECTOR, f"{current_selector_used} span[class*='DomoActionContainer__DomoIcon'], {current_selector_used} span.RidgeIcon").get_attribute("class") or ""))
+                )
+                aria_label_after = driver.find_element(By.CSS_SELECTOR, current_selector_used).get_attribute("aria-label")
+                logger.info(f"DOMOしました: {activity_id_for_log} (aria-label: {aria_label_after})")
+                time.sleep(delay_after_action)
+                return True
+            except TimeoutException:
+                logger.warning(f"DOMO実行後、状態変化の確認でタイムアウト: {activity_id_for_log}")
+                time.sleep(delay_after_action)
+                return False
+        else:
+            return False
+
+    except TimeoutException:
+        logger.warning(f"DOMO処理中にタイムアウト ({activity_id_for_log})。ページ要素が見つからないか、読み込みが遅い可能性があります。")
+    except NoSuchElementException:
+        logger.warning(f"DOMOボタンまたはその構成要素が見つかりません ({activity_id_for_log})。セレクタが古い可能性があります。")
+    except Exception as e:
+        logger.error(f"DOMO実行中に予期せぬエラー ({activity_id_for_log}):", exc_info=True)
+    return False

--- a/yamap_auto/follow_utils.py
+++ b/yamap_auto/follow_utils.py
@@ -1,0 +1,163 @@
+# coding: utf-8
+"""
+YAMAP フォロー関連ユーティリティ関数群
+主にリストアイテム内やプロフィールページでのフォロー操作を担当
+"""
+import time
+import logging
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException, NoSuchElementException
+
+from .driver_utils import get_main_config # main_config を取得するため
+
+logger = logging.getLogger(__name__)
+
+try:
+    main_config = get_main_config()
+    if not main_config:
+        logger.error("follow_utils: main_config の読み込みに失敗しました。")
+        main_config = {}
+except Exception as e:
+    logger.error(f"follow_utils: 設定情報 (main_config) の読み込み中にエラー: {e}", exc_info=True)
+    main_config = {}
+
+
+def find_follow_button_in_list_item(user_list_item_element):
+    """
+    ユーザーリストアイテム要素（例: フォロワー一覧の各ユーザー項目）内から
+    「フォローする」ボタンを探します。
+    既に「フォロー中」である場合や、クリック可能な「フォローする」ボタンがない場合はNoneを返します。
+
+    Args:
+        user_list_item_element (WebElement): 対象のユーザーリストアイテムのSelenium WebElement。
+
+    Returns:
+        WebElement or None: 「フォローする」ボタンのWebElement。見つからない場合はNone。
+    """
+    try:
+        # 1. 「フォロー中」ボタンの確認 (aria-pressed='true' が主な指標)
+        try:
+            following_button = user_list_item_element.find_element(By.CSS_SELECTOR, "button[aria-pressed='true']")
+            if following_button and following_button.is_displayed():
+                button_text = following_button.text.strip()
+                span_text = ""
+                try:
+                    span_elements = following_button.find_elements(By.CSS_SELECTOR, "span")
+                    if span_elements:
+                        span_text = " ".join(s.text.strip() for s in span_elements if s.text.strip())
+                except: pass
+
+                if "フォロー中" in button_text or "フォロー中" in span_text:
+                    logger.debug("リストアイテム内で「フォロー中」ボタンを発見 (aria-pressed='true' + テキスト)。既にフォロー済みと判断。")
+                    return None
+                else:
+                    logger.debug(f"aria-pressed='true' ボタン発見もテキスト不一致 (Button: '{button_text}', Span: '{span_text}')。フォロー済みと判断。")
+                    return None
+        except NoSuchElementException:
+            logger.debug("リストアイテム内に aria-pressed='true' の「フォロー中」ボタンは見つかりませんでした。フォロー可能かもしれません。")
+        except Exception as e_text_check:
+             logger.debug(f"aria-pressed='true' ボタンのテキスト確認中にエラー: {e_text_check}。フォロー済みと仮定。")
+             return None
+
+        # 2. 「フォローする」ボタンの探索
+        try:
+            potential_follow_buttons = user_list_item_element.find_elements(By.CSS_SELECTOR, "button[aria-pressed='false']")
+            if potential_follow_buttons:
+                for button_candidate in potential_follow_buttons:
+                    if button_candidate and button_candidate.is_displayed() and button_candidate.is_enabled():
+                        button_text = button_candidate.text.strip()
+                        span_text = ""
+                        try:
+                            span_elements = button_candidate.find_elements(By.CSS_SELECTOR, "span")
+                            if span_elements:
+                                span_text = " ".join(s.text.strip() for s in span_elements if s.text.strip())
+                        except: pass
+
+                        if "フォローする" in button_text or "フォローする" in span_text:
+                            logger.debug("リストアイテム内で「フォローする」ボタンを発見 (aria-pressed='false' + テキスト)。")
+                            return button_candidate
+            else:
+                logger.debug("リストアイテム内に aria-pressed='false' のボタン候補は見つかりませんでした。")
+        except NoSuchElementException:
+            logger.debug("リストアイテム内で aria-pressed='false' のボタン探索でエラー（通常発生しない）。")
+
+        try:
+            follow_button_xpath_str = ".//button[normalize-space(.)='フォローする']"
+            button_by_text = user_list_item_element.find_element(By.XPATH, follow_button_xpath_str)
+            if button_by_text and button_by_text.is_displayed() and button_by_text.is_enabled():
+                logger.debug(f"リストアイテム内で「フォローする」ボタンをテキストで発見 (XPath: {follow_button_xpath_str})。")
+                return button_by_text
+        except NoSuchElementException:
+            logger.debug(f"リストアイテム内でテキスト「フォローする」でのボタン発見試行失敗 (XPath)。")
+
+        try:
+            follow_button_aria_label = user_list_item_element.find_element(By.CSS_SELECTOR, "button[aria-label*='フォローする']")
+            if follow_button_aria_label and follow_button_aria_label.is_displayed() and follow_button_aria_label.is_enabled():
+                 logger.debug(f"リストアイテム内で「フォローする」ボタンをaria-labelで発見。")
+                 return follow_button_aria_label
+        except NoSuchElementException:
+            logger.debug("リストアイテム内で aria-label*='フォローする' のボタンは見つかりませんでした。")
+
+        logger.debug("ユーザーリストアイテム内にクリック可能な「フォローする」ボタンが見つかりませんでした。")
+        return None
+    except Exception as e:
+        logger.error(f"ユーザーリストアイテム内のフォローボタン検索で予期せぬエラー: {e}", exc_info=True)
+        return None
+
+def click_follow_button_and_verify(driver, follow_button_element, user_name_for_log=""):
+    """
+    指定された「フォローする」ボタンをクリックし、ボタンの状態が「フォロー中」に変わったことを確認します。
+    状態変化の確認は、ボタンの data-testid, aria-label, またはテキストの変更を監視します。
+
+    Args:
+        driver (webdriver.Chrome): Selenium WebDriverインスタンス。
+        follow_button_element (WebElement): クリック対象の「フォローする」ボタンのWebElement。
+        user_name_for_log (str, optional): ログ出力用のユーザー名。
+
+    Returns:
+        bool: フォローに成功し、状態変化も確認できた場合はTrue。それ以外はFalse。
+    """
+    try:
+        logger.info(f"ユーザー「{user_name_for_log}」のフォローボタンをクリックします...")
+
+        driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", follow_button_element)
+        time.sleep(0.1)
+        follow_button_element.click()
+
+        action_delays = main_config.get("action_delays", {})
+        delay_after_action = action_delays.get("after_follow_action_sec", 2.0)
+
+        WebDriverWait(driver, 10).until(
+            lambda d: (
+                (follow_button_element.get_attribute("data-testid") == "FollowingButton") or
+                ("フォロー中" in (follow_button_element.get_attribute("aria-label") or "")) or
+                ("フォロー中" in follow_button_element.text) or
+                (not follow_button_element.is_displayed())
+            )
+        )
+
+        final_testid = follow_button_element.get_attribute("data-testid")
+        final_aria_label = follow_button_element.get_attribute("aria-label")
+        final_text = ""
+        try:
+            final_text = follow_button_element.text
+        except: pass
+
+        if final_testid == "FollowingButton" or \
+           (final_aria_label and "フォロー中" in final_aria_label) or \
+           (final_text and "フォロー中" in final_text) or \
+           (not follow_button_element.is_displayed()):
+            logger.info(f"ユーザー「{user_name_for_log}」をフォローしました。状態: testid='{final_testid}', label='{final_aria_label}', text='{final_text}', displayed={follow_button_element.is_displayed()}")
+            time.sleep(delay_after_action)
+            return True
+        else:
+            logger.warning(f"フォローボタンクリック後、状態変化が期待通りではありません (ユーザー「{user_name_for_log}」)。状態: testid='{final_testid}', label='{final_aria_label}', text='{final_text}'")
+            return False
+    except TimeoutException:
+        logger.warning(f"フォロー後の状態変化待機中にタイムアウト (ユーザー: {user_name_for_log})。")
+        return False
+    except Exception as e:
+        logger.error(f"フォローボタンクリックまたは確認中にエラー (ユーザー: {user_name_for_log})", exc_info=True)
+        return False


### PR DESCRIPTION
- DOMO操作を行う `domo_activity` 関数を `domo_utils.py` に分割。
- リストアイテムからのフォロー操作（ボタン検索、クリック検証）を行う関数群を `follow_utils.py` に分割。
- `yamap_auto_domo.py` からこれらの関数を呼び出すように修正。
- `TASK_MANAGEMENT.md` を更新。