### PR TITLE
feat: タイムラインDOMO機能を一覧上で直接実行するよう改修

### DIFF
--- a/TASK_MANAGEMENT.md
+++ b/TASK_MANAGEMENT.md
@@ -20,7 +20,7 @@
 ## 💡 メモ / 改善案
 
 *   [x] フォローバックについて、「次へ」のページ遷移も行い全ページの確認を実施します (`max_pages_for_follow_back` 設定追加)
-*   [ ] タイムラインDOMO機能について、個別の記事に飛ばずに一覧上でDOMOする
+*   [x] タイムラインDOMO機能について、個別の記事に飛ばずに一覧上でDOMOする
 *   [ ] フォローバックについて、処理時間を大幅に短縮するようお願いします（処理時間計測機能を追加済み。今後この情報をもとに改善を行う）
 *   [ ] 新規フォローの拡充機能時も処理時間を大幅に短縮するようお願いします（処理時間計測機能を追加済み。今後この情報をもとに改善を行う）
     *   [ ] 検索＆フォロー機能への並列処理の導入検討（アカウントの安全性とYAMAPの規約を考慮）
@@ -100,6 +100,7 @@
 
 ## ✅ 完了タスク
 
+*   [x] タイムラインDOMO機能について、個別の記事に飛ばずに一覧上でDOMOするよう改修 ([THIS_COMMIT_HASH])
 *   [x] `domo_utils.py` の `domo_activity` 関数のエラーハンドリングとログ出力を強化 `[THIS_COMMIT_HASH]`
 *   [x] `yamap_auto_domo.py` 内のフォローバック処理 (`follow_back_users_new`) を `follow_back_utils.py` 等に分割 (現状 `follow_utils.py` に存在、これから `follow_back_utils.py` へ移動、実際には既に `follow_back_utils.py` に存在することを確認) `[THIS_COMMIT_HASH]`
 *   [x] `yamap_auto_domo.py` 内の検索結果処理 (`search_follow_and_domo_users`) を `search_utils.py` 等に分割 (現状 `follow_utils.py` に存在、これから `search_utils.py` へ移動、実際には既に `search_utils.py` に存在することを確認) `[THIS_COMMIT_HASH]`

--- a/yamap_auto/config.yaml
+++ b/yamap_auto/config.yaml
@@ -90,6 +90,31 @@ timeline_domo_settings:
   # タイムライン上でDOMOする活動記録の最大数。
   # タイムラインの新しい投稿から順に、この数に達するまでDOMOを試みます。
 
+  # === タイムライン一覧上での直接DOMOに関する追加設定 (vX.Y.Z以降) ===
+  # 以下の設定は、タイムラインの各活動記録ページに遷移せず、一覧上で直接DOMOを行う場合の動作を調整します。
+  # これにより、処理速度の向上が期待できます。
+
+  # domo_button_selectors_on_timeline:
+  #   - "button[data-testid='ActivityDomoButton']"
+  #   - "button#DomoActionButton"
+  #   - "div.ActivityItemActions__DomoActionContainer button" # ユーザー提供HTMLに基づく候補
+  # タイムラインのフィードアイテム内でDOMOボタンを見つけるためのCSSセレクタのリスト。
+  # 上から順に試行されます。YAMAPのUI変更に合わせて調整が必要になる場合があります。
+  # デフォルトでは、活動記録ページと同じセレクタと、一般的な候補が使用されます。
+
+  # domo_button_wait_sec_on_timeline: 3
+  # タイムラインのフィードアイテム内でDOMOボタンがクリック可能になるまでの最大待機時間 (秒単位)。
+  # デフォルトは3秒です。
+
+  # wait_after_feed_load_sec: 1.5
+  # タイムラインのフィードアイテム群が最初に読み込まれた後、処理を開始するまでの安定待ち時間 (秒単位)。
+  # デフォルトは1.5秒です。
+
+  # delay_between_item_processing_sec: 0.3
+  # タイムライン上の各フィードアイテムの処理（DOMO試行またはスキップ）が完了した後、
+  # 次のアイテムの処理を開始するまでの短い遅延時間 (秒単位)。 StaleElement対策や負荷軽減が目的です。
+  # デフォルトは0.3秒です。
+
   # タイムラインでの各DOMO実行後の待機時間は `action_delays.after_domo_sec` を参照します。
 
 search_and_follow_settings:

--- a/yamap_auto/domo_utils.py
+++ b/yamap_auto/domo_utils.py
@@ -244,118 +244,299 @@ def domo_timeline_activities(driver):
         logger.info("タイムラインDOMO機能は設定で無効になっています。")
         return
 
-    logger.info(">>> タイムラインDOMO機能を開始します...")
-    timeline_page_url = TIMELINE_URL # タイムラインページのURL
+    logger.info(">>> タイムラインDOMO機能を開始します (一覧上で直接DOMO)...")
+    timeline_page_url = TIMELINE_URL
     logger.info(f"タイムラインページへアクセス: {timeline_page_url}")
-    driver.get(timeline_page_url) # ページ遷移
+    driver.get(timeline_page_url)
 
-    # 設定値の読み込み
-    max_activities_to_domo = TIMELINE_DOMO_SETTINGS.get("max_activities_to_domo_on_timeline", 10) # DOMOする最大件数
-    domoed_count = 0 # このセッションでDOMOした件数
-    processed_activity_urls = set() # 既に処理試行した活動記録URLのセット (重複処理防止)
+    max_activities_to_domo = TIMELINE_DOMO_SETTINGS.get("max_activities_to_domo_on_timeline", 10)
+    domoed_count = 0
+    # processed_activity_ids: DOMO成功した活動記録ID（またはURL）を記録し、重複DOMOを防ぐ
+    # タイムライン上で同じ活動記録が複数回表示されるケースは稀だが念のため
+    processed_activity_identifiers = set()
+
+    # DOMOボタンのセレクタリスト (domo_activity と同じものをデフォルトで使用)
+    domo_button_selectors_for_timeline = TIMELINE_DOMO_SETTINGS.get(
+        "domo_button_selectors_on_timeline", # config.yaml でタイムライン専用セレクタを指定可能にする
+        [
+            "button[data-testid='ActivityDomoButton']", # プライマリ (活動ページと同じ想定)
+            "button#DomoActionButton",                   # セカンダリ (活動ページと同じ想定)
+            "div.ActivityItemActions__DomoActionContainer button" # 提供されたHTMLに基づく追加候補
+        ]
+    )
+    logger.debug(f"タイムラインDOMOで使用するボタンセレクタ: {domo_button_selectors_for_timeline}")
+
 
     try:
-        # --- タイムライン要素のセレクタ定義 ---
-        # YAMAPのUI変更に備え、セレクタは適宜更新が必要になる可能性があります。
-        feed_item_selector = "li.TimelineList__Feed" # 各フィードアイテム（投稿単位）
-        activity_item_indicator_selector = "div.TimelineActivityItem" # フィードアイテムが「活動日記」であることを示す要素
-        activity_link_in_item_selector = "a.TimelineActivityItem__BodyLink[href^='/activities/']" # 活動日記へのリンク
+        feed_item_selector = "li.TimelineList__Feed"
+        activity_item_indicator_selector = "div.TimelineActivityItem" # これで活動記録アイテムを特定
+        # activity_link_in_item_selector はログ用URL取得に使うが、DOMO処理には必須ではない
+        activity_link_in_item_selector = "a.TimelineActivityItem__BodyLink[href^='/activities/']"
 
-        # タイムラインのフィードアイテム群が表示されるまで待機
+
         logger.info(f"タイムラインのフィードアイテム ({feed_item_selector}) の出現を待ちます...")
         WebDriverWait(driver, 20).until(
             EC.presence_of_all_elements_located((By.CSS_SELECTOR, feed_item_selector))
         )
         logger.info("タイムラインのフィードアイテム群を発見。")
-        time.sleep(1.5) # スクロールや追加コンテンツ読み込みを考慮した描画安定待ち (以前は2.5秒)
+        time.sleep(TIMELINE_DOMO_SETTINGS.get("wait_after_feed_load_sec", 1.5)) # 設定から読み込み後待機時間を取得
 
-        # ページ上のフィードアイテム要素を全て取得
         feed_items = driver.find_elements(By.CSS_SELECTOR, feed_item_selector)
         logger.info(f"タイムラインから {len(feed_items)} 件のフィードアイテム候補を検出しました。")
 
-        if not feed_items: # アイテムがなければ処理終了
+        if not feed_items:
             logger.info("タイムラインにフィードアイテムが見つかりませんでした。")
             return
 
-        initial_feed_item_count = len(feed_items) # 処理開始時のアイテム数を記録
+        initial_feed_item_count = len(feed_items)
         logger.info(f"処理対象の初期フィードアイテム数: {initial_feed_item_count}")
 
-        # 各フィードアイテムを処理
-        for idx in range(initial_feed_item_count): # StaleElement対策のため、インデックスベースでループ
-            if domoed_count >= max_activities_to_domo: # DOMO上限に達したら終了
+        for idx in range(initial_feed_item_count):
+            if domoed_count >= max_activities_to_domo:
                 logger.info(f"タイムラインDOMOの上限 ({max_activities_to_domo}件) に達しました。")
                 break
 
-            activity_url = None # 対象の活動記録URL
+            activity_url_for_log = None # ログおよび重複判定用のURL
+            activity_id_for_log = "N/A"
+
             try:
-                # DOM操作やページ遷移で要素が無効になる (StaleElementReferenceException) 可能性を考慮し、
-                # ループの各反復でフィードアイテム要素を再取得します。
-                feed_items_on_page = driver.find_elements(By.CSS_SELECTOR, feed_item_selector)
-                if idx >= len(feed_items_on_page): # インデックスが現在の要素数を超えた場合 (DOMが大きく変わった可能性)
-                    logger.warning(f"フィードアイテムインデックス {idx} が現在のアイテム数 {len(feed_items_on_page)} を超えています。DOM変更の可能性。スキップします。")
+                # StaleElement対策: 各反復で要素を再取得
+                current_feed_items = driver.find_elements(By.CSS_SELECTOR, feed_item_selector)
+                if idx >= len(current_feed_items):
+                    logger.warning(f"フィードアイテムインデックス {idx} が現在のアイテム数 {len(current_feed_items)} を超えました。スキップ。")
                     continue
-                feed_item_element = feed_items_on_page[idx] # 現在処理対象のフィードアイテム
+                feed_item_element = current_feed_items[idx]
 
-                # このフィードアイテムが「活動日記」であるかを確認
-                activity_indicator_elements = feed_item_element.find_elements(By.CSS_SELECTOR, activity_item_indicator_selector)
-                if not activity_indicator_elements: # 活動日記でなければスキップ
-                    logger.debug(f"フィードアイテム {idx+1}/{initial_feed_item_count} は活動日記ではありません。スキップ。")
+                # 活動記録アイテムか確認
+                if not feed_item_element.find_elements(By.CSS_SELECTOR, activity_item_indicator_selector):
+                    logger.debug(f"フィードアイテム {idx+1}/{initial_feed_item_count} は活動記録ではありません。スキップ。")
                     continue
 
-                # 活動日記であれば、その中の活動記録ページへのリンクを取得
-                link_element = activity_indicator_elements[0].find_element(By.CSS_SELECTOR, activity_link_in_item_selector)
-                activity_url = link_element.get_attribute("href")
+                # URLを取得 (ログ用および重複DOMO防止用)
+                try:
+                    link_element = feed_item_element.find_element(By.CSS_SELECTOR, activity_link_in_item_selector)
+                    activity_url_for_log = link_element.get_attribute("href")
+                    if activity_url_for_log:
+                        if activity_url_for_log.startswith("/"):
+                            activity_url_for_log = BASE_URL + activity_url_for_log
+                        if "/activities/" in activity_url_for_log:
+                             activity_id_for_log = activity_url_for_log.split('/')[-1]
+                        else: # 有効な活動記録URLでない場合
+                            activity_url_for_log = None # 無効化
+                            activity_id_for_log = f"non_activity_item_{idx}" # ログ用の一時ID
+                except NoSuchElementException:
+                    logger.debug(f"フィードアイテム {idx+1} から活動記録URLリンク要素が見つかりません (ログ用)。activity_id: {activity_id_for_log}")
+                    activity_id_for_log = f"no_link_item_{idx}" # ログ用の一時ID
 
-                # URLの整形と検証
-                if activity_url:
-                    if activity_url.startswith("/"): # 相対URLならベースURLを付与
-                        activity_url = BASE_URL + activity_url
-                    if not activity_url.startswith(f"{BASE_URL}/activities/"): # 不正な形式なら無効化
-                        logger.warning(f"無効な活動記録URL形式です: {activity_url}。スキップします。")
-                        activity_url = None
-
-                if not activity_url: # URLが取得できなかった場合
-                    logger.warning(f"フィードアイテム {idx+1}/{initial_feed_item_count} から有効な活動記録URLを取得できませんでした。スキップ。")
+                # 重複DOMO試行の防止 (URLまたはIDが取得できた場合)
+                identifier_for_check = activity_url_for_log if activity_url_for_log else activity_id_for_log
+                if identifier_for_check != "N/A" and identifier_for_check in processed_activity_identifiers:
+                    logger.info(f"活動記録 ({identifier_for_check}) は既にDOMO成功済みとして記録されています。スキップ。")
                     continue
 
-                if activity_url in processed_activity_urls: # 既に処理試行済みならスキップ
-                    logger.info(f"活動記録 ({activity_url.split('/')[-1]}) は既に処理試行済みです。スキップ。")
-                    continue
-                processed_activity_urls.add(activity_url) # 処理済みセットに追加
+                logger.info(f"タイムライン活動記録 {idx+1}/{initial_feed_item_count} (ID/URL: {identifier_for_check}) のDOMOを試みます。")
 
-                logger.info(f"タイムライン活動記録 {idx+1}/{initial_feed_item_count} (URL: {activity_url.split('/')[-1]}) のDOMOを試みます。")
-
-                current_main_page_url = driver.current_url # DOMO処理前のURLを保存 (タイムラインページのURL)
-
-                # DOMO実行 (domo_activity関数は内部でページ遷移する可能性あり)
-                if domo_activity(driver, activity_url, BASE_URL): # BASE_URL を引数に追加
+                # 新しい関数でフィードアイテム上で直接DOMO
+                if domo_activity_on_timeline(driver, feed_item_element, domo_button_selectors_for_timeline, TIMELINE_DOMO_SETTINGS):
                     domoed_count += 1
+                    if identifier_for_check != "N/A":
+                         processed_activity_identifiers.add(identifier_for_check) # DOMO成功したものを記録
+                # domo_activity_on_timeline が False を返した場合 (既にDOMO済み、ボタンなし等) は domoed_count は増えない
 
-                # DOMO処理後、元のタイムラインページに戻る (URLが変わっていた場合)
-                if driver.current_url != current_main_page_url:
-                    logger.debug(f"DOMO処理後、元のタイムラインページ ({current_main_page_url}) に戻ります。")
-                    driver.get(current_main_page_url)
-                    try:
-                        # 戻った後、フィードアイテムが再認識されるように待つ
-                        WebDriverWait(driver, 10).until(
-                            EC.presence_of_element_located((By.CSS_SELECTOR, feed_item_selector))
-                        )
-                        time.sleep(0.2) # 短い追加の安定待ち (0.5秒から短縮)
-                    except TimeoutException:
-                        logger.warning(f"タイムラインページ ({current_main_page_url}) に戻った後、フィードアイテムの再表示タイムアウト。")
-                        # 処理は続行を試みる
+                # ページ遷移は発生しないので、タイムラインに戻る処理は不要
+                # StaleElementを避けるため、次のループの最初にフィードアイテムリストを再取得する
+                time.sleep(TIMELINE_DOMO_SETTINGS.get("delay_between_item_processing_sec", 0.3)) # アイテム処理間の短い遅延
 
-            except NoSuchElementException:
-                logger.warning(f"フィードアイテム {idx+1}/{initial_feed_item_count} 内で活動記録リンクが見つかりません。スキップします。")
-            except Exception as e_card_proc: # StaleElementReferenceExceptionもここでキャッチされる想定
-                logger.error(f"フィードアイテム {idx+1}/{initial_feed_item_count} (URL: {activity_url.split('/')[-1] if activity_url else 'N/A'}) の処理中にエラー: {e_card_proc}", exc_info=True)
+            except StaleElementReferenceException as e_stale:
+                logger.warning(f"フィードアイテム {idx+1} の処理中に StaleElementReferenceException: {e_stale}。DOMが変更された可能性があります。このアイテムをスキップします。")
+                # 必要であればここで driver.find_elements を再試行するなどのリカバリも検討できるが、一旦スキップ
+                time.sleep(0.5) # DOM安定待ち
+                continue # 次のアイテムへ
+            except NoSuchElementException: # activity_item_indicator_selector などが見つからない場合
+                logger.warning(f"フィードアイテム {idx+1}/{initial_feed_item_count} 内で必須要素が見つかりません。スキップします。")
+            except Exception as e_card_proc:
+                logger.error(f"フィードアイテム {idx+1}/{initial_feed_item_count} (ID/URL: {activity_url_for_log if activity_url_for_log else activity_id_for_log}) の処理中にエラー: {e_card_proc}", exc_info=True)
 
-    except TimeoutException: # タイムライン全体の読み込みタイムアウト
+    except TimeoutException:
         logger.warning("タイムライン活動記録の読み込みでタイムアウトしました。")
     except Exception as e: # その他の予期せぬエラー
         logger.error(f"タイムラインDOMO処理中に予期せぬエラーが発生しました。", exc_info=True)
 
     logger.info(f"<<< タイムラインDOMO機能完了。合計 {domoed_count} 件の活動記録にDOMOしました。")
+
+
+def domo_activity_on_timeline(driver, feed_item_element, domo_button_selectors, timeline_domo_settings):
+    """
+    タイムラインのフィードアイテム上で直接DOMOを実行します。
+    個別の活動記録ページには遷移しません。
+
+    Args:
+        driver (webdriver.Chrome): Selenium WebDriverインスタンス。
+        feed_item_element (WebElement): DOMO対象のフィードアイテム要素。
+        domo_button_selectors (list[str]): DOMOボタンを見つけるためのCSSセレクタのリスト。
+        timeline_domo_settings (dict): タイムラインDOMO関連の設定。
+
+    Returns:
+        bool: DOMOに成功した場合はTrue。既にDOMO済み、ボタンが見つからない、
+              またはエラーが発生した場合はFalse。
+    """
+    activity_id_for_log = "N/A" # アイテムからIDが取れれば更新
+    action_delays = main_config.get("action_delays", {})
+    delay_after_action = action_delays.get("after_domo_sec", 1.5)
+
+    try:
+        # フィードアイテム内から活動記録URLを取得試行 (ログ用)
+        activity_url_for_log = None
+        try:
+            link_element = feed_item_element.find_element(By.CSS_SELECTOR, "a.TimelineActivityItem__BodyLink[href^='/activities/']")
+            activity_url_for_log = link_element.get_attribute("href")
+            if activity_url_for_log and activity_url_for_log.startswith("/"):
+                activity_url_for_log = BASE_URL + activity_url_for_log
+            if activity_url_for_log and "/activities/" in activity_url_for_log:
+                activity_id_for_log = activity_url_for_log.split('/')[-1]
+        except NoSuchElementException:
+            logger.debug(f"フィードアイテム内から活動記録URLの取得に失敗 (ログ用)。activity_id: {activity_id_for_log}")
+            # URLがなくてもDOMO処理は続行
+
+        logger.info(f"タイムラインアイテム ({activity_id_for_log}) へ直接DOMOを試みます。")
+
+        # 1. DOMOボタンの探索 (フィードアイテム要素内を起点とする)
+        domo_button = None
+        current_selector_used = ""
+        button_found_but_not_clickable = False
+
+        for idx, selector in enumerate(domo_button_selectors):
+            logger.debug(f"DOMOボタン探索試行 #{idx+1} (セレクタ: '{selector}') in feed item: {activity_id_for_log}")
+            try:
+                # presence_of_element_located は driver を起点とするため、feed_item_element.find_element を使う
+                # WebDriverWait は要素の可視性やクリック可能性を待つために使用
+                wait_time = timeline_domo_settings.get("domo_button_wait_sec_on_timeline", 3) # 設定から待機時間を取得
+
+                # まず要素が存在するか確認 (feed_item_element を起点)
+                # WebDriverWait で feed_item_element を起点とした検索は直接サポートされないため、
+                # feed_item_element.find_element で探し、見つかればクリック可能か WebDriverWait で確認する
+                candidate_buttons = feed_item_element.find_elements(By.CSS_SELECTOR, selector)
+                if not candidate_buttons:
+                    logger.debug(f"セレクタ '{selector}' でDOMOボタン候補が見つかりません (in feed item: {activity_id_for_log})。")
+                    continue
+
+                # 複数のボタンが見つかる可能性は低いが一応最初の要素を対象とする
+                # クリック可能になるまで待機
+                domo_button_candidate = WebDriverWait(driver, wait_time).until(
+                    EC.element_to_be_clickable(candidate_buttons[0])
+                )
+
+                if domo_button_candidate:
+                    domo_button = domo_button_candidate
+                    current_selector_used = selector
+                    logger.info(f"DOMOボタンをフィードアイテム内で発見し、クリック可能です (使用セレクタ: '{selector}') for item: {activity_id_for_log}")
+                    button_found_but_not_clickable = False
+                    break
+                else:
+                    logger.debug(f"セレクタ '{selector}' でDOMOボタン候補が見つかりましたが、無効な要素でした (in feed item: {activity_id_for_log})。")
+            except TimeoutException:
+                if feed_item_element.find_elements(By.CSS_SELECTOR, selector):
+                    logger.warning(f"セレクタ '{selector}' でDOMOボタン要素はフィードアイテム内に存在しますが、クリック可能状態になりませんでした (item: {activity_id_for_log})。")
+                    button_found_but_not_clickable = True
+                else:
+                    logger.debug(f"セレクタ '{selector}' でDOMOボタンがフィードアイテム内で見つからず、タイムアウトしました (item: {activity_id_for_log})。")
+            except NoSuchElementException: # find_elements が空リストを返すので、ここは通常通らない
+                 logger.debug(f"セレクタ '{selector}' でDOMOボタンがフィードアイテム内で見つかりませんでした (NoSuchElement) (item: {activity_id_for_log})。")
+            except Exception as e_sel:
+                logger.warning(f"セレクタ '{selector}' でフィードアイテム内のDOMOボタン探索中に予期せぬエラー: {type(e_sel).__name__} - {e_sel} (item: {activity_id_for_log})", exc_info=False) # exc_info=False でスタックトレースを抑制
+
+        if not domo_button:
+            if button_found_but_not_clickable:
+                logger.error(f"DOMO失敗(Timeline): DOMOボタン要素はアイテム内に見つかりましたがクリック可能な状態ではありませんでした (item: {activity_id_for_log}, selectors: {domo_button_selectors})。")
+            else:
+                logger.error(f"DOMO失敗(Timeline): DOMOボタンがアイテム内で見つかりませんでした (item: {activity_id_for_log}, selectors: {domo_button_selectors})。")
+            return False
+
+        # 2. DOMO済みかどうかの判定
+        aria_label_before = domo_button.get_attribute("aria-label")
+        is_domoed = False
+
+        if aria_label_before and ("Domo済み" in aria_label_before or "domoed" in aria_label_before.lower() or "ドモ済み" in aria_label_before):
+            is_domoed = True
+        else:
+            try:
+                # アイコンのクラスで判定 (提供されたHTML断片に基づく)
+                # button要素の直接の子または孫に span.RidgeIcon がある想定
+                icon_span = domo_button.find_element(By.CSS_SELECTOR, "span.RidgeIcon, span[class*='DomoActionContainer__DomoIcon']") # より汎用的に
+                if "is-active" in (icon_span.get_attribute("class") or ""):
+                    is_domoed = True
+            except NoSuchElementException:
+                logger.debug(f"DOMOボタン内のis-activeアイコンspanが見つかりませんでした (item: {activity_id_for_log})。aria-labelに依存します。")
+
+        if is_domoed:
+            logger.info(f"既にDOMO済みです (タイムラインアイテム: {activity_id_for_log}, aria-label='{aria_label_before}')")
+            return False # 既にDOMO済みなのでFalseを返して処理終了 (DOMOは実行していない)
+
+        # 3. DOMO実行 (まだDOMOしていなければ)
+        logger.info(f"タイムラインアイテム ({activity_id_for_log}) 上でDOMOを実行します (使用ボタンセレクタ: '{current_selector_used}')")
+        try:
+            # 要素が画面内に表示されるようにスクロール (中央揃え)
+            driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", domo_button)
+            time.sleep(0.2) # スクロール後の描画待ち
+            domo_button.click()
+            logger.debug(f"DOMOボタンクリック実行 (item: {activity_id_for_log})。")
+        except Exception as e_click:
+            logger.error(f"DOMOボタンのクリックに失敗しました (item: {activity_id_for_log}): {e_click}", exc_info=True)
+            save_screenshot(driver, error_type="DOMO_ClickError_Timeline", context_info=f"{activity_id_for_log}")
+            return False
+
+        # 4. DOMO後の状態変化確認
+        try:
+            WebDriverWait(driver, 5).until(
+                lambda d: ("Domo済み" in (feed_item_element.find_element(By.CSS_SELECTOR, current_selector_used).get_attribute("aria-label") or "")) or \
+                          ("is-active" in (feed_item_element.find_element(By.CSS_SELECTOR, f"{current_selector_used} span.RidgeIcon, {current_selector_used} span[class*='DomoActionContainer__DomoIcon']").get_attribute("class") or ""))
+            )
+            # 状態変化後の属性をログ出力
+            final_button_state = "N/A"
+            try:
+                button_after_action = feed_item_element.find_element(By.CSS_SELECTOR, current_selector_used)
+                aria_label_after = button_after_action.get_attribute("aria-label")
+                icon_class_after = "N/A"
+                try:
+                    icon_after = button_after_action.find_element(By.CSS_SELECTOR, "span.RidgeIcon, span[class*='DomoActionContainer__DomoIcon']")
+                    icon_class_after = icon_after.get_attribute("class")
+                except: pass
+                final_button_state = f"aria-label='{aria_label_after}', icon_class='{icon_class_after}'"
+            except Exception as e_log_state:
+                 logger.debug(f"DOMO後の状態取得中に軽微なエラー: {e_log_state}")
+
+            logger.info(f"DOMO成功を確認しました (タイムラインアイテム: {activity_id_for_log}, 最終状態: {final_button_state})")
+            time.sleep(delay_after_action) # アクション後の適切な待機
+            return True
+        except TimeoutException:
+            # タイムアウト時の詳細ログ
+            actual_aria_label = "取得失敗"
+            actual_icon_class = "取得失敗"
+            try:
+                # feed_item_element を起点に再検索
+                button_element_after_click = feed_item_element.find_element(By.CSS_SELECTOR, current_selector_used)
+                actual_aria_label = button_element_after_click.get_attribute("aria-label") or "aria-labelなし"
+                try:
+                    icon_span_after_click = button_element_after_click.find_element(By.CSS_SELECTOR, "span.RidgeIcon, span[class*='DomoActionContainer__DomoIcon']")
+                    actual_icon_class = icon_span_after_click.get_attribute("class") or "classなし"
+                except NoSuchElementException:
+                    actual_icon_class = "アイコンspanなし"
+            except Exception as e_attr_confirm:
+                logger.error(f"DOMO後の属性取得中(確認タイムアウト内)にエラー: {type(e_attr_confirm).__name__} (item: {activity_id_for_log})")
+
+            logger.error(
+                f"DOMO失敗(Timeline): DOMO実行後、状態変化の確認でタイムアウト (Item: {activity_id_for_log}, セレクタ: '{current_selector_used}'). "
+                f"期待: aria-labelに'Domo済み' OR アイコンクラスに'is-active'. "
+                f"実際: aria-label='{actual_aria_label}', icon_class='{actual_icon_class}'"
+            )
+            save_screenshot(driver, error_type="DOMO_ConfirmTimeout_Timeline", context_info=f"{activity_id_for_log}_selector_{current_selector_used.replace('.', '_').replace('#', '_')}")
+            time.sleep(delay_after_action)
+            return False
+
+    except Exception as e:
+        logger.error(f"タイムラインアイテム ({activity_id_for_log}) 上でのDOMO実行中に予期せぬエラー: {type(e).__name__} - {e}", exc_info=True)
+        save_screenshot(driver, error_type="UnhandledException_DOMO_TimelineItem", context_info=f"{activity_id_for_log}_{type(e).__name__}")
+    return False
 
 
 # --- 並列処理用タスク関数 ---
@@ -424,25 +605,32 @@ def domo_timeline_activities_parallel(driver, shared_cookies):
         return
     # 並列処理自体が有効かチェック (config.yaml)
     if not PARALLEL_PROCESSING_SETTINGS.get("enable_parallel_processing", False):
-        logger.info("並列処理が無効なため、タイムラインDOMOは逐次実行されます。")
-        return domo_timeline_activities(driver) # 並列無効時は逐次版を呼び出す
+        logger.info("並列処理が無効なため、タイムラインDOMOは逐次実行されます (一覧DOMO版)。")
+        # 逐次版 (domo_timeline_activities) は既に一覧DOMOに対応済みのため、それを呼び出す
+        return domo_timeline_activities(driver)
 
-    logger.info(">>> [PARALLEL] タイムラインDOMO機能を開始します...")
+    # --- 以下、並列処理版のロジック (現状はURL収集ベースのまま) ---
+    # TODO: この並列処理版も、domo_activity_on_timeline を使うように改修が必要。
+    #       WebElementをスレッド間で安全に扱うか、あるいはフィードアイテムの
+    #       一意な識別子（例：活動記録IDやdata属性）を収集し、各タスクで
+    #       再度要素を検索・操作する方式を検討する必要がある。
+    #       現状は、URLを収集して各URLのページに遷移してDOMOする古い方式のまま。
+    logger.warning("[PARALLEL] 現在のタイムラインDOMO並列処理版は、まだ一覧上での直接DOMOに対応していません。")
+    logger.warning("[PARALLEL] 各活動記録ページに遷移してDOMOする従来の並列処理を実行します。")
+
+    logger.info(">>> [PARALLEL - Legacy URL based] タイムラインDOMO機能を開始します...")
     timeline_page_url = TIMELINE_URL
     logger.info(f"タイムラインページへアクセスし、DOMO対象URLを収集します: {timeline_page_url}")
-    driver.get(timeline_page_url) # URLリスト収集はメインのドライバーで行う
+    driver.get(timeline_page_url)
 
-    # 設定値の読み込み
-    max_activities_to_domo = TIMELINE_DOMO_SETTINGS.get("max_activities_to_domo_on_timeline", 10) # DOMO上限
-    max_workers = PARALLEL_PROCESSING_SETTINGS.get("max_workers", 3) # 並列ワーカー数
-    task_delay_base = PARALLEL_PROCESSING_SETTINGS.get("delay_between_thread_tasks_sec", 1.0) # タスク間の基本遅延
+    max_activities_to_domo = TIMELINE_DOMO_SETTINGS.get("max_activities_to_domo_on_timeline", 10)
+    max_workers = PARALLEL_PROCESSING_SETTINGS.get("max_workers", 3)
+    task_delay_base = PARALLEL_PROCESSING_SETTINGS.get("delay_between_thread_tasks_sec", 1.0)
 
-    activity_urls_to_domo = [] # DOMO対象の活動記録URLを格納するリスト
-    processed_urls_for_collection = set() # URL収集段階での重複排除用セット
+    activity_urls_to_domo = []
+    processed_urls_for_collection = set()
 
     try:
-        # --- URL収集フェーズ ---
-        # タイムライン要素のセレクタ (逐次版と同じ)
         feed_item_selector = "li.TimelineList__Feed"
         activity_item_indicator_selector = "div.TimelineActivityItem"
         activity_link_in_item_selector = "a.TimelineActivityItem__BodyLink[href^='/activities/']"
@@ -452,67 +640,58 @@ def domo_timeline_activities_parallel(driver, shared_cookies):
             EC.presence_of_all_elements_located((By.CSS_SELECTOR, feed_item_selector))
         )
         logger.info("タイムラインのフィードアイテム群を発見。URL収集を開始します。")
-        time.sleep(1.5) # 描画安定待ち
+        time.sleep(TIMELINE_DOMO_SETTINGS.get("wait_after_feed_load_sec", 1.5))
+
 
         feed_items = driver.find_elements(By.CSS_SELECTOR, feed_item_selector)
         if not feed_items:
             logger.info("タイムラインにフィードアイテムが見つかりませんでした（URL収集フェーズ）。")
             return
 
-        # 各フィードアイテムから活動記録URLを収集
         for idx, feed_item_element in enumerate(feed_items):
-            if len(activity_urls_to_domo) >= max_activities_to_domo: # 収集上限に達したら終了
+            if len(activity_urls_to_domo) >= max_activities_to_domo:
                 logger.info(f"DOMO対象URLの収集上限 ({max_activities_to_domo}件) に達しました。")
                 break
             try:
-                # このフィードアイテムが活動日記か確認
-                activity_indicator_elements = feed_item_element.find_elements(By.CSS_SELECTOR, activity_item_indicator_selector)
-                if not activity_indicator_elements: continue # 活動日記でなければスキップ
+                if not feed_item_element.find_elements(By.CSS_SELECTOR, activity_item_indicator_selector):
+                    continue
 
-                # 活動記録URLを取得
-                link_element = activity_indicator_elements[0].find_element(By.CSS_SELECTOR, activity_link_in_item_selector)
+                link_element = feed_item_element.find_element(By.CSS_SELECTOR, activity_link_in_item_selector)
                 activity_url = link_element.get_attribute("href")
 
-                # URLの整形と検証、重複チェック
                 if activity_url:
                     if activity_url.startswith("/"): activity_url = BASE_URL + activity_url
-                    if not activity_url.startswith(f"{BASE_URL}/activities/"): continue # 不正形式
-                    if activity_url in processed_urls_for_collection: continue # 既に収集済み
+                    if not activity_url.startswith(f"{BASE_URL}/activities/"): continue
+                    if activity_url in processed_urls_for_collection: continue
 
-                    activity_urls_to_domo.append(activity_url) # リストに追加
-                    processed_urls_for_collection.add(activity_url) # セットに追加
-                    logger.debug(f"DOMO候補URL追加: {activity_url.split('/')[-1]} (収集済み: {len(activity_urls_to_domo)}件)")
-            except Exception as e_collect: # URL収集中にエラーが発生した場合 (StaleElementなど)
-                logger.warning(f"タイムラインからのURL収集中にエラー (アイテム {idx+1}): {e_collect}")
-                # ここではシンプルにスキップし、次のアイテムの処理を試みる
+                    activity_urls_to_domo.append(activity_url)
+                    processed_urls_for_collection.add(activity_url)
+                    logger.debug(f"DOMO候補URL追加 (Legacy Parallel): {activity_url.split('/')[-1]} (収集済み: {len(activity_urls_to_domo)}件)")
+            except Exception as e_collect:
+                logger.warning(f"タイムラインからのURL収集中にエラー (アイテム {idx+1}, Legacy Parallel): {e_collect}")
 
-        logger.info(f"収集したDOMO対象URLは {len(activity_urls_to_domo)} 件です。")
-        if not activity_urls_to_domo: # DOMO対象URLが0件なら終了
-            logger.info("DOMO対象となる活動記録URLが収集できませんでした。")
+        logger.info(f"収集したDOMO対象URLは {len(activity_urls_to_domo)} 件です (Legacy Parallel)。")
+        if not activity_urls_to_domo:
+            logger.info("DOMO対象となる活動記録URLが収集できませんでした (Legacy Parallel)。")
             return
 
-        # --- 並列DOMO実行フェーズ ---
-        total_domoed_count_parallel = 0 # 並列処理でDOMOした総数
-        # ThreadPoolExecutorを使用して、収集したURLに対して並列でDOMOタスクを実行
+        total_domoed_count_parallel = 0
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = [] # 各タスクのFutureオブジェクトを格納するリスト
+            futures = []
             for i, url in enumerate(activity_urls_to_domo):
-                # 各タスクに少しずつ異なる遅延を与えることで、同時アクセスを緩和
-                delay_for_this_task = task_delay_base + (i * 0.1) # 例: 0.1秒ずつ開始をずらす
-                # domo_activity_task をサブミット (引数としてURL, 共有Cookie, 遅延時間を渡す)
+                delay_for_this_task = task_delay_base + (i * 0.1)
                 futures.append(executor.submit(domo_activity_task, url, shared_cookies, delay_for_this_task))
 
-            # 全てのタスクが完了するのを待ち、結果を集計
-            for future in as_completed(futures): # 完了したものから順に処理
+            for future in as_completed(futures):
                 try:
-                    if future.result(): # domo_activity_task が True (DOMO成功) を返した場合
+                    if future.result():
                         total_domoed_count_parallel += 1
-                except Exception as e_future: # タスク実行中に例外が発生した場合
-                    logger.error(f"並列DOMOタスクの実行結果取得中にエラー: {e_future}", exc_info=True)
+                except Exception as e_future:
+                    logger.error(f"並列DOMOタスクの実行結果取得中にエラー (Legacy Parallel): {e_future}", exc_info=True)
 
-        logger.info(f"<<< [PARALLEL] タイムラインDOMO機能完了。合計 {total_domoed_count_parallel} 件の活動記録にDOMOしました (試行対象: {len(activity_urls_to_domo)}件)。")
+        logger.info(f"<<< [PARALLEL - Legacy URL based] タイムラインDOMO機能完了。合計 {total_domoed_count_parallel} 件の活動記録にDOMOしました (試行対象: {len(activity_urls_to_domo)}件)。")
 
-    except TimeoutException: # URL収集フェーズでのタイムアウト
-        logger.warning("[PARALLEL] タイムライン活動記録のURL収集でタイムアウトしました。")
-    except Exception as e: # その他の予期せぬエラー
-        logger.error(f"[PARALLEL] タイムラインDOMO処理 (並列) 中に予期せぬエラーが発生しました。", exc_info=True)
+    except TimeoutException:
+        logger.warning("[PARALLEL - Legacy URL based] タイムライン活動記録のURL収集でタイムアウトしました。")
+    except Exception as e:
+        logger.error(f"[PARALLEL - Legacy URL based] タイムラインDOMO処理中に予期せぬエラーが発生しました。", exc_info=True)


### PR DESCRIPTION
YAMAPタイムライン上の活動記録に対し、個別のページに遷移せずに
直接DOMOを実行するように以下のファイルを変更しました。

- `yamap_auto/domo_utils.py`:
    - `domo_activity_on_timeline` 関数を新設し、フィードアイテム要素内で DOMOボタンの探索、実行、状態確認を行うロジックを実装。
    - `domo_timeline_activities` 関数を上記新関数を利用するように改修。 ページ遷移をなくし、一覧上でのDOMO処理を実現。
    - `domo_timeline_activities_parallel` は今回の改修対象外とし、 その旨をコメントとログで明記。
- `yamap_auto/config.yaml`:
    - `timeline_domo_settings` に、一覧DOMO用の新しい設定項目 (ボタンセレクタ、待機時間など) の説明と記述例を追加。
- `TASK_MANAGEMENT.md`:
    - 関連タスクを完了済みに更新し、最終更新日時を更新。

これにより、タイムラインDOMO機能の処理効率向上が期待されます。
並列処理版のタイムラインDOMO機能については、今後の課題とします。