### PR TITLE
feat: フォローバック及び検索＆フォロー機能の並列処理化による高速化

### DIFF
--- a/yamap_auto/config.yaml
+++ b/yamap_auto/config.yaml
@@ -70,15 +70,27 @@ follow_back_settings:
   # true: フォローバック機能を有効にします。
   # false: フォローバック機能を無効にします。
 
-  max_users_to_follow_back: 15
+  max_users_to_follow_back: 3 # テスト用に変更
   # 一度のスクリプト実行でフォローバックする最大のユーザー数。
   # フォロワーリストの複数ページをチェックする場合、この合計数に達すると処理を停止します。
 
-  max_pages_for_follow_back: 5
+  max_pages_for_follow_back: 1 # テスト用に変更
   # フォローバック対象者を探すために、フォロワーリストの何ページ目まで確認するかを指定します。
   # 例えば `5` を指定すると、最新のフォロワーから最大5ページ分遡って確認します。
 
-  # フォローバック実行後の待機時間は `action_delays.after_follow_action_sec` を参照します。
+  enable_parallel_follow_back: true # テスト用に変更
+  # true: フォローバック機能の並列処理を有効にします。
+  # false: 従来の逐次処理を実行します。
+
+  max_workers_follow_back: 2
+  # フォローバック機能を並列処理する場合の最大ワーカー（スレッド）数。
+  # enable_parallel_follow_back が true の場合に参照されます。
+
+  delay_per_worker_action_sec: 2.5 # (追加)
+  # 並列フォローバック時、各ワーカースレッドがフォローアクションを実行した後の個別の遅延時間 (秒単位)。
+  # 逐次処理の場合は action_delays.after_follow_action_sec が使用されます。
+
+  # 従来の逐次処理でのフォローバック実行後の待機時間は `action_delays.after_follow_action_sec` を参照します。
 
 timeline_domo_settings:
   # タイムラインDOMO機能に関する設定 (YAMAPのタイムライン上の活動記録に自動でDOMOする)
@@ -127,11 +139,11 @@ search_and_follow_settings:
   # 処理を開始する活動記録の検索結果ページのURL。
   # 通常はデフォルトのままで問題ありませんが、特定の検索条件で開始したい場合にカスタマイズ可能です。
 
-  max_pages_to_process_search: 3
+  max_pages_to_process_search: 1 # テスト用に変更
   # 検索結果の何ページ目まで処理を続けるかを指定します。
   # 例えば `3` を指定すると、最初のページから3ページ目まで処理します。
 
-  max_users_to_process_per_page: 5
+  max_users_to_process_per_page: 3 # テスト用に変更
   # 検索結果の各ページで、最大何人のユーザー（活動記録の投稿者）を処理対象とするかを指定します。
 
   min_followers_for_search_follow: 20
@@ -154,6 +166,18 @@ search_and_follow_settings:
   delay_after_pagination_sec: 3.0
   # 検索結果のページネーション（「次へ」ボタンクリックなど）を実行した後の待機時間 (秒単位)。
   # 新しいページのコンテンツが完全に読み込まれるのを待つために使用します。
+
+  enable_parallel_search_follow: true # テスト用に変更
+  # true: 検索＆フォロー機能のユーザー処理部分を並列化します。
+  # false: 従来の逐次処理を実行します。
+
+  max_workers_search_follow: 2
+  # 検索＆フォロー機能を並列処理する場合の最大ワーカー（スレッド）数。
+  # enable_parallel_search_follow が true の場合に参照されます。
+
+  delay_per_worker_user_processing_sec: 3.5 # (追加)
+  # 並列検索＆フォロー時、各ワーカースレッドが1ユーザーの処理を完了した後の個別の遅延時間 (秒単位)。
+  # 逐次処理の場合は delay_between_user_processing_in_search_sec が使用されます。
 
 # === 並列処理設定 ===
 # スクリプト内の一部の処理（現在はタイムラインDOMO）を並列実行するための設定です。

--- a/yamap_auto/follow_back_utils.py
+++ b/yamap_auto/follow_back_utils.py
@@ -9,9 +9,11 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException, NoSuchElementException
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from selenium import webdriver # 並列処理でwebdriverを直接使うため
 
-# .driver_utils から main_config の読み込み関数をインポート
-from .driver_utils import get_main_config
+# .driver_utils から main_config の読み込み関数と Cookie付きドライバ作成関数をインポート
+from .driver_utils import get_main_config, create_driver_with_cookies, get_driver_options
 # .follow_utils からフォローボタン検索・クリック関数をインポート
 from .follow_utils import find_follow_button_in_list_item, click_follow_button_and_verify
 
@@ -21,155 +23,349 @@ logger = logging.getLogger(__name__)
 BASE_URL = "https://yamap.com" # このファイルでも直接URLを組み立てるために必要
 
 # --- 設定情報の読み込み ---
-try:
-    main_config = get_main_config()
-    if not main_config:
-        logger.error("follow_back_utils: main_config の読み込みに失敗しました。")
-        main_config = {} # フォールバック
+_main_config_cache = None
+def _get_config_cached():
+    """ 設定情報をキャッシュを使って取得 """
+    global _main_config_cache
+    if _main_config_cache is None:
+        _main_config_cache = get_main_config()
+        if not _main_config_cache:
+            logger.error("follow_back_utils: main_config の読み込みに失敗しました。")
+            _main_config_cache = {} # フォールバック
+    return _main_config_cache
 
-    # FOLLOW_BACK_SETTINGS と ACTION_DELAYS を main_config から取得
-    FOLLOW_BACK_SETTINGS = main_config.get("follow_back_settings", {})
-    ACTION_DELAYS = main_config.get("action_delays", {}) # ページネーション遅延などで使用
-
-    if not FOLLOW_BACK_SETTINGS:
+def _get_follow_back_settings():
+    config = _get_config_cached()
+    settings = config.get("follow_back_settings", {})
+    if not settings:
         logger.warning("follow_back_utils: config.yaml に follow_back_settings が見つからないか空です。")
-    # ACTION_DELAYS は必須ではないかもしれないので warning は出さない
+    return settings
 
-except Exception as e:
-    logger.error(f"follow_back_utils: 設定情報 (main_config) の読み込み中にエラー: {e}", exc_info=True)
-    FOLLOW_BACK_SETTINGS = {} # フォールバック
-    ACTION_DELAYS = {}       # フォールバック
+def _get_action_delays():
+    config = _get_config_cached()
+    return config.get("action_delays", {})
+
+# --- 並列処理用ワーカースレッドタスク ---
+def _follow_back_task(page_url, user_profile_url_to_find, user_name_to_find, shared_cookies, follow_back_settings_for_task, action_delays_for_task, current_user_id_for_task):
+    """
+    並列処理用のワーカースレッドタスク。
+    指定されたページURLにアクセスし、対象ユーザーを見つけてフォローバックを試みる。
+    """
+    task_driver = None
+    followed_in_task = False
+    status_message = f"ユーザー「{user_name_to_find}」({user_profile_url_to_find.split('/')[-1]}): "
+    try:
+        # Cookieを使って新しいWebDriverインスタンスを作成
+        # (create_driver_with_cookies は driver_utils にある想定)
+        task_driver = create_driver_with_cookies(shared_cookies, base_url_to_visit_first=page_url)
+        if not task_driver:
+            logger.error(f"{status_message}WebDriverの作成に失敗。タスクを中止。")
+            return {"profile_url": user_profile_url_to_find, "followed": False, "error": "WebDriver作成失敗"}
+
+        # 念のため、再度ページURLにアクセス (create_driver_with_cookies内で既にアクセスしている場合もある)
+        task_driver.get(page_url)
+        WebDriverWait(task_driver, 20).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, "ul.css-18aka15")) # followers_list_container_selector
+        )
+        time.sleep(0.5) # 描画待ち
+
+        # ページ内で対象ユーザーのカードを探す
+        # user_card_selector = "div[data-testid='user']"
+        # user_link_in_card_selector = "a.css-e5vv35[href^='/users/']"
+        all_cards_on_page_in_task = task_driver.find_elements(By.CSS_SELECTOR, "div[data-testid='user']")
+        target_card_element = None
+        for card in all_cards_on_page_in_task:
+            try:
+                link_el = card.find_element(By.CSS_SELECTOR, "a.css-e5vv35[href^='/users/']")
+                href = link_el.get_attribute("href")
+                if href:
+                    if href.startswith("/"): href = BASE_URL + href
+                    if href == user_profile_url_to_find:
+                        target_card_element = card
+                        break
+            except NoSuchElementException:
+                continue # このカードは対象外
+
+        if not target_card_element:
+            logger.warning(f"{status_message}ページ ({page_url}) 内で対象ユーザーカードが見つかりませんでした。")
+            return {"profile_url": user_profile_url_to_find, "followed": False, "error": "対象ユーザーカード発見失敗"}
+
+        # フォローボタンを探してクリック
+        follow_button = find_follow_button_in_list_item(target_card_element)
+        if follow_button:
+            logger.info(f"{status_message}はまだフォローしていません。並列タスク内でフォローバックを実行します。")
+            # 並列処理用の遅延を使用
+            delay_worker_action = follow_back_settings_for_task.get("delay_per_worker_action_sec", 2.5)
+            if click_follow_button_and_verify(task_driver, follow_button, user_name_to_find):
+                followed_in_task = True
+            time.sleep(delay_worker_action)
+        else:
+            logger.info(f"{status_message}は既にフォロー済みか、フォローボタンが見つかりませんでした（並列タスク内）。")
+            time.sleep(0.2) # 短い遅延
+
+        return {"profile_url": user_profile_url_to_find, "followed": followed_in_task, "error": None}
+
+    except Exception as e_task:
+        logger.error(f"{status_message}並列処理タスク中にエラー: {e_task}", exc_info=True)
+        return {"profile_url": user_profile_url_to_find, "followed": False, "error": str(e_task)}
+    finally:
+        if task_driver:
+            task_driver.quit()
 
 
-# --- フォローバック機能 ---
-def follow_back_users_new(driver, current_user_id):
+# --- フォローバック機能 (メインロジック) ---
+def follow_back_users_new(driver, current_user_id, shared_cookies_from_main=None):
     """
     自分をフォローしてくれたユーザーをフォローバックする機能。
     config.yaml の follow_back_settings に従って動作する。
-    ページネーションに対応し、複数のフォロワーページを確認する。
+    並列処理に対応。
     """
-    if not FOLLOW_BACK_SETTINGS.get("enable_follow_back", False):
+    fb_settings = _get_follow_back_settings()
+    action_delays = _get_action_delays()
+
+    if not fb_settings.get("enable_follow_back", False):
         logger.info("フォローバック機能は設定で無効になっています。")
         return
 
-    logger.info(">>> フォローバック機能を開始します...")
+    is_parallel_enabled = fb_settings.get("enable_parallel_follow_back", False)
+    max_workers = fb_settings.get("max_workers_follow_back", 2) if is_parallel_enabled else 1
+    # shared_cookies_from_main は yamap_auto_domo.py から渡される想定
+    # 並列処理でCookieが必須なので、なければ逐次実行にフォールバックも検討できる
+    if is_parallel_enabled and not shared_cookies_from_main:
+        logger.warning("並列フォローバックが有効ですが、共有Cookieが提供されませんでした。逐次処理にフォールバックします。")
+        is_parallel_enabled = False
+
+
+    logger.info(f">>> フォローバック機能を開始します... (並列処理: {'有効' if is_parallel_enabled else '無効'})")
     base_followers_url = f"{BASE_URL}/users/{current_user_id}?tab=followers"
     current_page_number = 1
 
-    logger.info(f"フォロワー一覧の初期ページへアクセス: {base_followers_url}#tabs")
+    # メインのdriverで初期ページにアクセス
+    logger.info(f"フォロワー一覧の初期ページへアクセス: {base_followers_url}#tabs (メインドライバー使用)")
     driver.get(base_followers_url + "#tabs")
 
-    max_to_follow_back_total = FOLLOW_BACK_SETTINGS.get("max_users_to_follow_back", 10)
-    max_pages_to_check = FOLLOW_BACK_SETTINGS.get("max_pages_for_follow_back", 100) # 以前の max_pages_to_process_follow_back から変更された可能性
-    delay_between_actions = FOLLOW_BACK_SETTINGS.get("delay_after_follow_back_action_sec", 3.0)
-    delay_after_pagination_fb = ACTION_DELAYS.get("delay_after_pagination_sec", 3.0)
+    max_to_follow_back_total = fb_settings.get("max_users_to_follow_back", 10)
+    max_pages_to_check = fb_settings.get("max_pages_for_follow_back", 100)
+    # 逐次処理用の遅延 (並列時はワーカースレッド側で `delay_per_worker_action_sec` を使用)
+    sequential_delay_between_actions = action_delays.get("after_follow_action_sec", # 旧 config の delay_after_follow_back_action_sec に相当するものを探す
+                                                       fb_settings.get("delay_after_follow_back_action_sec", 3.0)) # フォールバック
+    delay_after_pagination_fb = action_delays.get("delay_after_pagination_sec", 3.0)
 
 
     total_followed_this_session = 0
+    # processed_profile_urls_this_session は、メインスレッドでURLを収集し、
+    # タスク投入前に重複チェックするために使用する。タスク側では処理しない。
     processed_profile_urls_this_session = set()
 
-    followers_list_container_selector = "ul.css-18aka15" # フォロワー一覧のUL要素
-    user_card_selector = "div[data-testid='user']" # 各ユーザーカードのコンテナ
-    user_link_in_card_selector = "a.css-e5vv35[href^='/users/']" # カード内のユーザープロフへのリンク
-    next_button_selectors = [ # 次のページボタンの可能性のあるセレクタリスト
-        "button[aria-label=\"次のページに移動する\"]", # 提供されたHTMLに完全一致するセレクタを先頭に追加
+    followers_list_container_selector = "ul.css-18aka15"
+    user_card_selector = "div[data-testid='user']"
+    user_link_in_card_selector = "a.css-e5vv35[href^='/users/']"
+    next_button_selectors = [
+        "button[aria-label=\"次のページに移動する\"]",
         "a[data-testid='pagination-next-button']", "a[rel='next']", "a.next",
         "a.pagination__next", "button.next", "button.pagination__next",
         "a[aria-label*='次へ']:not([aria-disabled='true'])", "a[aria-label*='Next']:not([aria-disabled='true'])",
         "button[aria-label*='次へ']:not([disabled])", "button[aria-label*='Next']:not([disabled])"
     ]
 
-    while current_page_number <= max_pages_to_check:
-        logger.info(f"フォロワーリストの {current_page_number} ページ目を処理します。")
-        try:
-            WebDriverWait(driver, 20).until(
-                EC.presence_of_element_located((By.CSS_SELECTOR, followers_list_container_selector))
-            )
-            logger.info("フォロワーリストのコンテナを発見。")
-            time.sleep(1.0) # リスト内容の描画待ち
+    with ThreadPoolExecutor(max_workers=max_workers) if is_parallel_enabled else nullcontext() as executor:
+        futures = [] # 並列処理の場合のFutureオブジェクトリスト
 
-            user_cards_all_on_page = driver.find_elements(By.CSS_SELECTOR, user_card_selector)
-            logger.info(f"{current_page_number} ページ目から {len(user_cards_all_on_page)} 件のユーザーカード候補を検出しました。")
-
-            user_cards_to_process_this_page = user_cards_all_on_page
-            # 各ページの先頭N件をスキップするロジック (設定により有効化)
-            if FOLLOW_BACK_SETTINGS.get("enable_per_page_skip", True):
-                skip_count = FOLLOW_BACK_SETTINGS.get("users_to_skip_per_page", 3)
-                if skip_count > 0 and len(user_cards_all_on_page) > skip_count:
-                    user_cards_to_process_this_page = user_cards_all_on_page[skip_count:]
-                    logger.info(f"各ページ先頭{skip_count}件のスキップ設定が有効なため、このページの先頭{skip_count}件を除いた {len(user_cards_to_process_this_page)} 件のフォロワー候補を処理対象とします。")
-                elif skip_count > 0: # スキップ数がカード数以上の場合
-                    logger.info(f"各ページ先頭{skip_count}件のスキップ設定が有効ですが、ユーザーカードが{len(user_cards_all_on_page)}件のため、このページでは全件スキップ（処理対象なし）となります。")
-                    user_cards_to_process_this_page = [] # 処理対象を空にする
-                # skip_countが0以下の場合は何もしない (全件処理)
-            else:
-                logger.info("各ページ先頭のユーザースキップ機能は無効です。検出された全ユーザーを処理対象とします。")
-
-
-            if not user_cards_to_process_this_page:
-                logger.info(f"{current_page_number} ページ目には処理対象となるフォロワーが見つかりませんでした（スキップ処理後を含む）。")
-                # 「次へ」ボタンがない場合はここでループを抜けるべき
-                # (次の「次へ」ボタン探索ロジックで対応される)
-
-            for card_idx, user_card_element in enumerate(user_cards_to_process_this_page):
-                if total_followed_this_session >= max_to_follow_back_total:
-                    logger.info(f"セッション中のフォローバック上限 ({max_to_follow_back_total}人) に達しました。")
-                    break # このページのユーザー処理ループを抜ける
-
-                user_name = f"ユーザー{card_idx+1} (Page {current_page_number})" # デフォルト名
-                profile_url = ""
-                try:
-                    # ユーザーカードからプロフィールURLと名前を取得
-                    user_link_element = user_card_element.find_element(By.CSS_SELECTOR, user_link_in_card_selector)
-                    profile_url = user_link_element.get_attribute("href")
-
-                    # 名前取得の試み (複数の可能性を考慮)
-                    name_el_candidates = user_link_element.find_elements(By.CSS_SELECTOR, "h2, span[class*='UserListItem_name__'], span.name") # 一般的な名前要素候補
-                    for name_el_candidate in name_el_candidates:
-                        if name_el_candidate.text.strip():
-                            user_name = name_el_candidate.text.strip()
-                            break
-
-                    if not profile_url:
-                        logger.warning(f"フォロワーカード {card_idx+1} からプロフィールURLが取得できませんでした。スキップ。")
-                        continue
-                    if profile_url.startswith("/"): profile_url = BASE_URL + profile_url # 相対URLを絶対URLに
-
-                    # 自分自身や無効なURLはスキップ
-                    if f"/users/{current_user_id}" in profile_url or not profile_url.startswith(f"{BASE_URL}/users/"):
-                        logger.debug(f"スキップ対象: 自分自身または無効なプロフィールURL ({profile_url})")
-                        continue
-
-                    # このセッションで既に処理（試行）したURLならスキップ
-                    if profile_url in processed_profile_urls_this_session:
-                        logger.info(f"ユーザー「{user_name}」({profile_url.split('/')[-1]}) はこのセッションで既に処理済みのためスキップ。")
-                        continue
-
-                except NoSuchElementException:
-                    logger.warning(f"フォロワーカード {card_idx+1} の必須要素 (リンク等) が見つかりません。スキップ。")
-                    continue
-                except Exception as e_card_parse:
-                    logger.warning(f"フォロワーカード {card_idx+1} の解析中に予期せぬエラー: {e_card_parse}。スキップ。")
-                    continue
-
-                processed_profile_urls_this_session.add(profile_url) # これから処理するのでセットに追加
-                logger.info(f"フォロワー「{user_name}」(URL: {profile_url.split('/')[-1]}) のフォロー状態を確認します...")
-
-                # フォローボタンを探す (follow_utilsからインポートした関数を使用)
-                follow_button = find_follow_button_in_list_item(user_card_element)
-
-                if follow_button:
-                    logger.info(f"ユーザー「{user_name}」はまだフォローしていません。フォローバックを実行します。")
-                    if click_follow_button_and_verify(driver, follow_button, user_name): # follow_utilsからインポート
-                        total_followed_this_session += 1
-                    time.sleep(delay_between_actions) # アクション後の遅延
-                else:
-                    logger.info(f"ユーザー「{user_name}」は既にフォロー済みであるか、フォローボタンが見つかりませんでした。スキップ。")
-                    time.sleep(0.5) # 短い遅延
-
-            # --- ページ内の全ユーザー処理後 ---
+        while current_page_number <= max_pages_to_check:
             if total_followed_this_session >= max_to_follow_back_total:
-                logger.info("セッション中のフォローバック上限に達したため、ページネーションを停止します。")
+                logger.info(f"セッション中のフォローバック上限 ({max_to_follow_back_total}人) に達しました。ページネーションを停止。")
+                break # ページネーションループ (while) を抜ける
+
+            current_page_url_for_task = driver.current_url # タスクに渡す現在のページURL
+            logger.info(f"フォロワーリストの {current_page_number} ページ目 ({current_page_url_for_task}) を処理します。")
+
+            try:
+                WebDriverWait(driver, 20).until(
+                    EC.presence_of_element_located((By.CSS_SELECTOR, followers_list_container_selector))
+                )
+                logger.info("フォロワーリストのコンテナをメインドライバーで発見。")
+                time.sleep(1.0) # リスト内容の描画待ち (メインドライバー)
+
+                user_cards_all_on_page = driver.find_elements(By.CSS_SELECTOR, user_card_selector)
+                logger.info(f"{current_page_number} ページ目から {len(user_cards_all_on_page)} 件のユーザーカード候補を検出 (メインドライバー)。")
+
+                user_cards_to_process_this_page = user_cards_all_on_page
+                if fb_settings.get("enable_per_page_skip", True):
+                    skip_count = fb_settings.get("users_to_skip_per_page", 3)
+                    if skip_count > 0 and len(user_cards_all_on_page) > skip_count:
+                        user_cards_to_process_this_page = user_cards_all_on_page[skip_count:]
+                        logger.info(f"各ページ先頭{skip_count}件のスキップ設定が有効なため、このページの先頭{skip_count}件を除いた {len(user_cards_to_process_this_page)} 件を処理対象とします。")
+                    elif skip_count > 0:
+                        logger.info(f"スキップ対象がカード数以上のため、このページでは全件スキップ。")
+                        user_cards_to_process_this_page = []
+                    # else: スキップなし
+                else:
+                    logger.info("各ページ先頭のユーザースキップ機能は無効。検出された全ユーザーを処理対象とします。")
+
+                if not user_cards_to_process_this_page:
+                    logger.info(f"{current_page_number} ページ目には処理対象となるフォロワーが見つかりませんでした（スキップ処理後を含む）。")
+                    # 「次へ」ボタンの処理はループの最後で行う
+
+                tasks_for_this_page = []
+                for card_idx, user_card_element_main_driver in enumerate(user_cards_to_process_this_page):
+                    if total_followed_this_session + len(futures) >= max_to_follow_back_total and is_parallel_enabled : # 並列時は投入タスク数も考慮
+                         logger.info(f"フォローバック上限 ({max_to_follow_back_total}人) に近づいたため、新規タスク投入を停止します。")
+                         break
+                    if total_followed_this_session >= max_to_follow_back_total and not is_parallel_enabled: # 逐次処理の場合
+                         logger.info(f"フォローバック上限 ({max_to_follow_back_total}人) に達しました。")
+                         break
+
+                    user_name_main = f"ユーザー{card_idx+1} (Page {current_page_number}, MainDriver)"
+                    profile_url_main = ""
+                    try:
+                        user_link_element_main = user_card_element_main_driver.find_element(By.CSS_SELECTOR, user_link_in_card_selector)
+                        profile_url_main = user_link_element_main.get_attribute("href")
+
+                        name_el_candidates_main = user_link_element_main.find_elements(By.CSS_SELECTOR, "h2, span[class*='UserListItem_name__'], span.name")
+                        for name_el_candidate_main in name_el_candidates_main:
+                            if name_el_candidate_main.text.strip():
+                                user_name_main = name_el_candidate_main.text.strip()
+                                break
+
+                        if not profile_url_main:
+                            logger.warning(f"{user_name_main}: プロフィールURL取得失敗。スキップ。")
+                            continue
+                        if profile_url_main.startswith("/"): profile_url_main = BASE_URL + profile_url_main
+
+                        if f"/users/{current_user_id}" in profile_url_main or not profile_url_main.startswith(f"{BASE_URL}/users/"):
+                            logger.debug(f"スキップ対象: 自分自身または無効なURL ({profile_url_main})")
+                            continue
+                        if profile_url_main in processed_profile_urls_this_session:
+                            logger.info(f"ユーザー「{user_name_main}」({profile_url_main.split('/')[-1]}) は既に処理試行済み。スキップ。")
+                            continue
+
+                    except NoSuchElementException:
+                        logger.warning(f"{user_name_main}: カード必須要素(リンク等)が見つかりません。スキップ。")
+                        continue
+                    except Exception as e_card_parse_main:
+                        logger.warning(f"{user_name_main}: カード解析中に予期せぬエラー: {e_card_parse_main}。スキップ。")
+                        continue
+
+                    processed_profile_urls_this_session.add(profile_url_main) # メインスレッドで処理済みとしてマーク
+
+                    # --- ここで逐次処理と並列処理の分岐 ---
+                    if is_parallel_enabled and executor:
+                        # 並列処理: タスクを投入
+                        logger.info(f"フォロワー「{user_name_main}」(URL: {profile_url_main.split('/')[-1]}) のフォローバックタスクを投入します...")
+                        # fb_settings と action_delays をタスクに渡す
+                        future = executor.submit(_follow_back_task, current_page_url_for_task, profile_url_main, user_name_main, shared_cookies_from_main, fb_settings, action_delays, current_user_id)
+                        futures.append(future)
+                    else:
+                        # 逐次処理: メインドライバーで直接処理
+                        logger.info(f"フォロワー「{user_name_main}」(URL: {profile_url_main.split('/')[-1]}) のフォロー状態を逐次確認します...")
+                        follow_button_main = find_follow_button_in_list_item(user_card_element_main_driver)
+                        if follow_button_main:
+                            logger.info(f"ユーザー「{user_name_main}」はまだフォローしていません。逐次フォローバックを実行します。")
+                            if click_follow_button_and_verify(driver, follow_button_main, user_name_main):
+                                total_followed_this_session += 1
+                            time.sleep(sequential_delay_between_actions)
+                        else:
+                            logger.info(f"ユーザー「{user_name_main}」は既にフォロー済みか、ボタンが見つかりませんでした（逐次）。")
+                            time.sleep(0.5)
+                # --- ページ内の全ユーザーカード処理後 (逐次処理の場合) ---
+                if not is_parallel_enabled and total_followed_this_session >= max_to_follow_back_total:
+                    logger.info("逐次処理でフォローバック上限に達したため、ページネーションを停止します。")
+                    break # while ループを抜ける
+
+            except TimeoutException:
+                logger.warning(f"{current_page_number} ページ目のリストコンテナ読み込みタイムアウト(メインドライバー)。")
+                break # while ループを抜ける
+            except Exception as e_page_process_main:
+                logger.error(f"{current_page_number} ページ目の処理中(メインドライバー)に予期せぬエラー: {e_page_process_main}", exc_info=True)
+                break # while ループを抜ける
+
+            # --- 「次へ」ボタンの処理 (メインドライバー) ---
+            if total_followed_this_session >= max_to_follow_back_total and not is_parallel_enabled: # 逐次処理の上限チェック
+                 break
+            if is_parallel_enabled and executor and (total_followed_this_session + len(futures) >= max_to_follow_back_total): # 並列処理の上限チェック
+                 logger.info("並列タスク投入数が上限に近いため、次のページへは進みません。残タスク処理後に終了します。")
+                 break
+
+
+            next_button_found_on_page = False
+            current_url_before_pagination = driver.current_url
+            logger.info("現在のページのフォロワー処理完了(メインドライバー)。「次へ」ボタンを探します...")
+            for selector_idx, selector in enumerate(next_button_selectors):
+                try:
+                    next_button = WebDriverWait(driver, 5).until(
+                        EC.element_to_be_clickable((By.CSS_SELECTOR, selector))
+                    )
+                    if next_button.is_displayed() and next_button.is_enabled():
+                        logger.info(f"「次へ」ボタンをセレクタ '{selector}' で発見(メインドライバー)。クリックします。")
+                        driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", next_button)
+                        time.sleep(0.5)
+                        next_button.click()
+                        next_button_found_on_page = True
+                        break
+                except TimeoutException:
+                    logger.debug(f"セレクタ '{selector}' で「次へ」ボタンが見つからずタイムアウト ({selector_idx+1}/{len(next_button_selectors)}).")
+                except Exception as e_click_next_main:
+                    logger.warning(f"セレクタ '{selector}' で「次へ」ボタンのクリック試行中(メインドライバー)にエラー: {e_click_next_main}")
+
+            if not next_button_found_on_page:
+                logger.info("「次へ」ボタンが見つかりませんでした(メインドライバー)。最終ページと判断。")
+                break # while ループを抜ける
+
+            try:
+                WebDriverWait(driver, 15).until(EC.url_changes(current_url_before_pagination))
+                logger.info(f"次のフォロワーページ ({driver.current_url}) へ正常に遷移(メインドライバー)。")
+                WebDriverWait(driver, 10).until(
+                    EC.presence_of_element_located((By.CSS_SELECTOR, followers_list_container_selector))
+                )
+                time.sleep(delay_after_pagination_fb)
+            except TimeoutException:
+                logger.warning("「次へ」ボタンクリック後、ページ遷移またはリスト再表示タイムアウト(メインドライバー)。")
+                break # while ループを抜ける
+            current_page_number += 1
+        # --- ページネーションループ (while) 終了 ---
+
+        # 並列処理の場合、残っているタスクの結果を処理
+        if is_parallel_enabled and futures:
+            logger.info(f"投入済みの {len(futures)} 件の並列フォローバックタスクの結果を処理します...")
+            for future_item in as_completed(futures):
+                if total_followed_this_session >= max_to_follow_back_total:
+                    # 個々のタスクはキャンセルできないが、結果の処理はスキップできる
+                    # logger.info("フォローバック上限に達したため、残りのタスク結果処理はスキップします。")
+                    # continue # continueするとエラー結果なども見逃すので、結果は最後まで見る
+                    pass # 上限には達したが、エラー等がないか確認するために結果は処理する
+
+                try:
+                    result = future_item.result()
+                    profile_url_res = result.get("profile_url", "不明なURL")
+                    user_name_res = profile_url_res.split('/')[-1] # 簡易表示用
+                    if result.get("error"):
+                        logger.error(f"並列タスクエラー (ユーザー: {user_name_res}): {result['error']}")
+                    elif result.get("followed"):
+                        logger.info(f"ユーザー「{user_name_res}」のフォローバックに成功しました（並列タスク）。")
+                        if total_followed_this_session < max_to_follow_back_total: # 上限チェックしてから加算
+                            total_followed_this_session += 1
+                        else:
+                             logger.info(f"ユーザー「{user_name_res}」はフォロー成功しましたが、既に上限 ({max_to_follow_back_total}) に達していたためカウント外とします。")
+                    else:
+                        # フォローしなかった場合 (既にフォロー済み、ボタンなしなど)
+                        logger.info(f"ユーザー「{user_name_res}」は並列タスク内でフォローバックされませんでした。")
+                except Exception as e_future:
+                    logger.error(f"並列フォローバックタスクの結果取得中にエラー: {e_future}", exc_info=True)
+
+
+    logger.info(f"<<< フォローバック機能完了。このセッションで合計 {total_followed_this_session} 人をフォローバックしました。")
+
+
+# nullcontext for Python < 3.7 (concurrent.futures might be used without `with`)
+# For simplicity, assuming Python 3.7+ where `nullcontext` is available or not strictly needed if `with` isn't used for sequential.
+# However, to make the code cleaner with a conditional `with` statement:
+try:
+    from contextlib import nullcontext
+except ImportError:
+    import contextlib
+    @contextlib.contextmanager
+    def nullcontext(enter_result=None):
+        yield enter_result
                 break # ページネーションループ (while) を抜ける
 
             # 「次へ」ボタンの探索とクリック

--- a/yamap_auto/search_utils.py
+++ b/yamap_auto/search_utils.py
@@ -9,9 +9,11 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException, NoSuchElementException
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from selenium import webdriver # 並列処理でwebdriverを直接使うため
 
-# .driver_utils から main_config の読み込み関数をインポート
-from .driver_utils import get_main_config
+# .driver_utils から main_config の読み込み関数と Cookie付きドライバ作成関数をインポート
+from .driver_utils import get_main_config, create_driver_with_cookies, get_driver_options
 # .user_profile_utils から必要な関数をインポート
 from .user_profile_utils import (
     get_latest_activity_url,
@@ -34,231 +36,364 @@ logger = logging.getLogger(__name__)
 BASE_URL = "https://yamap.com"
 SEARCH_ACTIVITIES_URL_DEFAULT = f"{BASE_URL}/search/activities"
 
-# --- 設定情報の読み込み ---
-try:
-    main_config = get_main_config()
-    if not main_config:
-        logger.error("search_utils: main_config の読み込みに失敗しました。")
-        # main_config がないと後続の処理でエラーになるため、空の辞書で初期化
-        main_config = {}
+# --- 設定情報の読み込み (キャッシュ対応) ---
+_main_config_cache_sf = None
+def _get_config_cached_sf():
+    global _main_config_cache_sf
+    if _main_config_cache_sf is None:
+        _main_config_cache_sf = get_main_config()
+        if not _main_config_cache_sf:
+            logger.error("search_utils: main_config の読み込みに失敗しました。")
+            _main_config_cache_sf = {}
+    return _main_config_cache_sf
 
-    # SEARCH_AND_FOLLOW_SETTINGS と ACTION_DELAYS を main_config から取得
-    SEARCH_AND_FOLLOW_SETTINGS = main_config.get("search_and_follow_settings", {})
-    ACTION_DELAYS = main_config.get("action_delays", {}) # こちらも main_config 直下を想定
-
-    if not SEARCH_AND_FOLLOW_SETTINGS:
+def _get_search_follow_settings():
+    config = _get_config_cached_sf()
+    settings = config.get("search_and_follow_settings", {})
+    if not settings:
         logger.warning("search_utils: config.yaml に search_and_follow_settings が見つからないか空です。")
-    # ACTION_DELAYS は必須ではないかもしれないので warning は出さない
+    return settings
 
-except Exception as e:
-    logger.error(f"search_utils: 設定情報 (main_config) の読み込み中にエラー: {e}", exc_info=True)
-    # エラー発生時は空の辞書でフォールバックし、機能が安全に何もしないようにする
-    SEARCH_AND_FOLLOW_SETTINGS = {}
-    ACTION_DELAYS = {}
+def _get_action_delays_sf():
+    config = _get_config_cached_sf()
+    return config.get("action_delays", {})
 
 
-# --- 検索からのフォロー＆DOMO機能 ---
-def search_follow_and_domo_users(driver, current_user_id):
+# --- 並列処理用ワーカースレッドタスク ---
+def _search_follow_domo_task(user_profile_url, user_name_for_log, shared_cookies, sf_settings, ad_settings, current_user_id_for_task):
+    """
+    並列処理用のワーカースレッドタスク。
+    指定されたユーザープロフィールURLにアクセスし、条件確認、フォロー、DOMOを実行する。
+    """
+    task_driver = None
+    task_followed_count = 0
+    task_domoed_count = 0
+    status_message = f"ユーザー「{user_name_for_log}」(URL: {user_profile_url.split('/')[-1]}): "
+    try:
+        task_driver = create_driver_with_cookies(shared_cookies, base_url_to_visit_first=BASE_URL) # BASE_URLに一度アクセス
+        if not task_driver:
+            logger.error(f"{status_message}WebDriverの作成に失敗。タスクを中止。")
+            return {"profile_url": user_profile_url, "followed": 0, "domoed": 0, "error": "WebDriver作成失敗"}
+
+        logger.info(f"{status_message}プロフィールページ ({user_profile_url}) へアクセスします (並列タスク)。")
+        task_driver.get(user_profile_url)
+        try:
+            WebDriverWait(task_driver, 20).until(
+                EC.all_of(
+                    EC.url_contains(user_profile_url.split('/')[-1]),
+                    EC.visibility_of_element_located((By.CSS_SELECTOR, "h1.css-jctfiw")), # プロフィール名
+                    lambda d: d.execute_script("return document.readyState") == "complete",
+                    EC.presence_of_element_located((By.CSS_SELECTOR, "footer.css-1yg0z07")) # フッター
+                )
+            )
+        except TimeoutException:
+            logger.warning(f"{status_message}プロフィールページ読み込みタイムアウト（並列タスク）。")
+            return {"profile_url": user_profile_url, "followed": 0, "domoed": 0, "error": "プロフィールページ読み込みタイムアウト"}
+
+        if user_profile_url not in task_driver.current_url: # 稀にリダイレクトされるケースなどへの対処
+            logger.error(f"{status_message}URL不一致: プロフィールページ ({user_profile_url}) にいるはずが、現在のURLは {task_driver.current_url} です。スキップします。")
+            return {"profile_url": user_profile_url, "followed": 0, "domoed": 0, "error": "プロフィールページURL不一致"}
+
+
+        follow_button_on_profile = find_follow_button_on_profile_page(task_driver)
+        if not follow_button_on_profile:
+            logger.info(f"{status_message}既にフォロー済みか、フォローボタンがありません（並列タスク）。")
+            return {"profile_url": user_profile_url, "followed": 0, "domoed": 0, "error": None, "skipped_reason": "既にフォロー済み/ボタンなし"}
+
+        min_followers = sf_settings.get("min_followers_for_search_follow", 20)
+        ratio_threshold = sf_settings.get("follow_ratio_threshold_for_search", 0.9)
+        domo_after_follow_task = sf_settings.get("domo_latest_activity_after_follow", True)
+        delay_worker_user_proc = sf_settings.get("delay_per_worker_user_processing_sec", 3.5)
+
+
+        follows, followers = get_user_follow_counts(task_driver, user_profile_url)
+        if follows == -1 or followers == -1:
+            logger.warning(f"{status_message}フォロー数/フォロワー数が取得できませんでした（並列タスク）。")
+            return {"profile_url": user_profile_url, "followed": 0, "domoed": 0, "error": "フォロー数/フォロワー数取得失敗"}
+        if followers < min_followers:
+            logger.info(f"{status_message}フォロワー数 ({followers}) が閾値 ({min_followers}) 未満（並列タスク）。")
+            return {"profile_url": user_profile_url, "followed": 0, "domoed": 0, "error": None, "skipped_reason": f"フォロワー数不足({followers}<{min_followers})"}
+
+        current_ratio = (follows / followers) if followers > 0 else float('inf')
+        logger.info(f"{status_message}F中={follows}, Fワー={followers}, Ratio={current_ratio:.2f} (閾値: >= {ratio_threshold})（並列タスク）")
+        if not (current_ratio >= ratio_threshold):
+            logger.info(f"{status_message}Ratio ({current_ratio:.2f}) が閾値 ({ratio_threshold}) 未満（並列タスク）。")
+            return {"profile_url": user_profile_url, "followed": 0, "domoed": 0, "error": None, "skipped_reason": f"Ratio不足({current_ratio:.2f}<{ratio_threshold})"}
+
+        logger.info(f"{status_message}フォロー条件を満たしました。フォローします（並列タスク）。")
+        if click_follow_button_and_verify(task_driver, follow_button_on_profile, user_name_for_log):
+            task_followed_count = 1
+            if domo_after_follow_task:
+                logger.info(f"{status_message}最新活動記録にDOMOを試みます（並列タスク）。")
+                latest_act_url = get_latest_activity_url(task_driver, user_profile_url)
+                if latest_act_url:
+                    if domo_activity(task_driver, latest_act_url, BASE_URL): # BASE_URL を渡す
+                        task_domoed_count = 1
+                else:
+                    logger.info(f"{status_message}最新活動記録が見つからず、DOMOできませんでした（並列タスク）。")
+
+        time.sleep(delay_worker_user_proc)
+        return {"profile_url": user_profile_url, "followed": task_followed_count, "domoed": task_domoed_count, "error": None}
+
+    except Exception as e_task:
+        logger.error(f"{status_message}並列処理タスク中にエラー: {e_task}", exc_info=True)
+        return {"profile_url": user_profile_url, "followed": 0, "domoed": 0, "error": str(e_task)}
+    finally:
+        if task_driver:
+            task_driver.quit()
+
+
+# --- 検索からのフォロー＆DOMO機能 (メインロジック) ---
+def search_follow_and_domo_users(driver, current_user_id, shared_cookies_from_main=None):
     """
     活動記録検索ページを巡回し、条件に合うユーザーをフォローし、
     そのユーザーの最新活動記録にDOMOする。
-    config.yaml の search_and_follow_settings に従って動作する。
+    config.yaml の search_and_follow_settings に従って動作する。並列処理対応。
     """
-    if not SEARCH_AND_FOLLOW_SETTINGS.get("enable_search_and_follow", False):
+    sf_settings = _get_search_follow_settings()
+    ad_settings = _get_action_delays_sf()
+
+    if not sf_settings.get("enable_search_and_follow", False):
         logger.info("検索からのフォロー＆DOMO機能は設定で無効になっています。")
         return
 
-    logger.info(">>> 検索からのフォロー＆DOMO機能を開始します...")
+    is_parallel_enabled = sf_settings.get("enable_parallel_search_follow", False)
+    max_workers = sf_settings.get("max_workers_search_follow", 2) if is_parallel_enabled else 1
+    if is_parallel_enabled and not shared_cookies_from_main:
+        logger.warning("並列検索＆フォローが有効ですが、共有Cookieが提供されませんでした。逐次処理にフォールバックします。")
+        is_parallel_enabled = False
 
-    start_url = SEARCH_AND_FOLLOW_SETTINGS.get("search_activities_url", SEARCH_ACTIVITIES_URL_DEFAULT)
-    max_pages = SEARCH_AND_FOLLOW_SETTINGS.get("max_pages_to_process_search", 1)
-    max_users_per_page = SEARCH_AND_FOLLOW_SETTINGS.get("max_users_to_process_per_page", 5)
-    min_followers = SEARCH_AND_FOLLOW_SETTINGS.get("min_followers_for_search_follow", 20)
-    ratio_threshold = SEARCH_AND_FOLLOW_SETTINGS.get("follow_ratio_threshold_for_search", 0.9)
-    domo_after_follow = SEARCH_AND_FOLLOW_SETTINGS.get("domo_latest_activity_after_follow", True)
-    delay_user_processing = SEARCH_AND_FOLLOW_SETTINGS.get("delay_between_user_processing_in_search_sec", 5.0)
-    delay_pagination = ACTION_DELAYS.get("delay_after_pagination_sec", 3.0)
+    logger.info(f">>> 検索からのフォロー＆DOMO機能を開始します... (並列処理: {'有効' if is_parallel_enabled else '無効'})")
+
+    start_url = sf_settings.get("search_activities_url", SEARCH_ACTIVITIES_URL_DEFAULT)
+    max_pages = sf_settings.get("max_pages_to_process_search", 1)
+    max_users_per_page = sf_settings.get("max_users_to_process_per_page", 5)
+    # 逐次処理用の遅延 (並列時はワーカースレッド側で `delay_per_worker_user_processing_sec` を使用)
+    sequential_delay_user_processing = sf_settings.get("delay_between_user_processing_in_search_sec", 5.0)
+    delay_pagination = ad_settings.get("delay_after_pagination_sec", 3.0) # これはACTION_DELAYSから取得
+
+    # 並列/逐次共通の設定
+    min_followers_seq = sf_settings.get("min_followers_for_search_follow", 20)
+    ratio_threshold_seq = sf_settings.get("follow_ratio_threshold_for_search", 0.9)
+    domo_after_follow_seq = sf_settings.get("domo_latest_activity_after_follow", True)
 
 
-    total_followed_count = 0
-    total_domoed_count = 0
+    total_followed_count_session = 0
+    total_domoed_count_session = 0
 
     activity_card_selector = "article[data-testid='activity-entry']"
     user_profile_link_in_card_selector = "div.css-1vh31zw > a.css-k2fvpp[href^='/users/']"
 
-    processed_profile_urls = set()
+    # processed_profile_urls はセッション全体で共有し、重複処理を避ける
+    processed_profile_urls_session = set()
 
-    for page_num in range(1, max_pages + 1):
-        processed_users_on_current_page = 0
-        current_page_url_before_action = driver.current_url
 
-        if page_num > 1:
-            logger.info(f"{page_num-1}ページ目の処理完了。次のページ ({page_num}ページ目) へ遷移を試みます。")
-            next_button_selectors = [
-                "a[data-testid='pagination-next-button']", "a[rel='next']", "a.next",
-                "a.pagination__next", "button.next", "button.pagination__next",
-                "a[aria-label*='次へ']:not([aria-disabled='true'])", "a[aria-label*='Next']:not([aria-disabled='true'])",
-                "button[aria-label*='次へ']:not([disabled])", "button[aria-label*='Next']:not([disabled])"
-            ]
-            next_button_found = False
-            for selector in next_button_selectors:
-                try:
-                    next_button = WebDriverWait(driver, 5).until(
-                        EC.element_to_be_clickable((By.CSS_SELECTOR, selector))
-                    )
-                    if next_button.is_displayed() and next_button.is_enabled():
-                        logger.info(f"次のページボタンをセレクタ '{selector}' で発見。クリックします。")
-                        driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", next_button)
-                        time.sleep(0.5)
-                        next_button.click()
-                        next_button_found = True
-                        break
-                except TimeoutException: logger.debug(f"セレクタ '{selector}' で次のページボタンが見つからずタイムアウト。")
-                except Exception as e_click: logger.warning(f"セレクタ '{selector}' でボタンクリック試行中にエラー: {e_click}")
+    with ThreadPoolExecutor(max_workers=max_workers) if is_parallel_enabled else nullcontext() as executor:
+        for page_num in range(1, max_pages + 1):
+            processed_users_on_current_page_count = 0 # このページで実際に処理(タスク投入or逐次処理)したユーザー数
+            futures_this_page = [] # このページで投入した並列タスクのFuture
 
-            if not next_button_found:
-                logger.info("試行した全てのセレクタで、クリック可能な「次へ」ボタンが見つかりませんでした。検索結果のページネーション処理を終了します。")
-                break
-            try:
-                WebDriverWait(driver, 10).until(EC.url_changes(current_page_url_before_action))
-                logger.info(f"{page_num}ページ目へ遷移しました。新しいURL: {driver.current_url}")
-                WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CSS_SELECTOR, activity_card_selector)))
-                logger.info(f"{page_num}ページ目の活動記録カードの読み込みを確認。")
-                time.sleep(delay_pagination)
-            except TimeoutException:
-                logger.warning(f"{page_num}ページ目への遷移後、URL変化または活動記録カードの読み込みタイムアウト。処理を終了します。")
-                break
-            except Exception as e_page_load:
-                logger.error(f"{page_num}ページ目への遷移または読み込み中に予期せぬエラー: {e_page_load}", exc_info=True)
-                break
+            current_page_url_for_log = driver.current_url # ページネーション前のURLをログ用に保持
 
-        if page_num == 1 and driver.current_url != start_url :
-             logger.info(f"{page_num}ページ目の活動記録検索結果 ({start_url}) にアクセスします。")
-             driver.get(start_url)
-        try:
-            WebDriverWait(driver, 15).until(EC.presence_of_all_elements_located((By.CSS_SELECTOR, activity_card_selector)))
-        except TimeoutException:
-            page_identifier_for_log = start_url if page_num == 1 else driver.current_url
-            logger.warning(f"活動記録検索結果ページ ({page_identifier_for_log}) で活動記録カードの読み込みタイムアウト。このページの処理をスキップします。")
-            continue
-
-        initial_activity_cards_on_page = driver.find_elements(By.CSS_SELECTOR, activity_card_selector)
-        num_cards_to_process = len(initial_activity_cards_on_page)
-        logger.info(f"{page_num}ページ目: {num_cards_to_process} 件の活動記録候補を検出。")
-        if not initial_activity_cards_on_page:
-            logger.info("このページには活動記録が見つかりませんでした。")
-            continue
-
-        for card_idx in range(num_cards_to_process):
-            if processed_users_on_current_page >= max_users_per_page:
-                logger.info(f"このページでの処理上限 ({max_users_per_page}ユーザー) に達しました。")
-                break
-            user_profile_url = None
-            user_name_for_log = f"活動記録{card_idx+1}のユーザー"
-            try:
-                current_activity_cards = driver.find_elements(By.CSS_SELECTOR, activity_card_selector)
-                if card_idx >= len(current_activity_cards):
-                    logger.warning(f"カードインデックス {card_idx} が現在のカード数 {len(current_activity_cards)} を超えています。DOM構造が変更された可能性があります。このカードの処理をスキップします。")
-                    continue
-                card_element = current_activity_cards[card_idx]
-                profile_link_el = WebDriverWait(card_element, 5).until(
-                    EC.presence_of_element_located((By.CSS_SELECTOR, user_profile_link_in_card_selector))
-                )
-                href = profile_link_el.get_attribute("href")
-                if href:
-                    if href.startswith("/"): user_profile_url = BASE_URL + href
-                    elif href.startswith(BASE_URL): user_profile_url = href
-                if not user_profile_url or f"/users/{current_user_id}" in user_profile_url:
-                    logger.debug(f"無効なプロフィールURLか自分自身 ({user_profile_url}) のためスキップ。")
-                    continue
-                if user_profile_url in processed_profile_urls:
-                    logger.info(f"ユーザー ({user_profile_url.split('/')[-1]}) は既に処理済みのためスキップ。")
-                    continue
-                try:
-                    name_el = profile_link_el.find_element(By.CSS_SELECTOR, "span, img[alt]")
-                    if name_el.tag_name == "img": user_name_for_log = name_el.get_attribute("alt")
-                    else: user_name_for_log = name_el.text.strip()
-                    if not user_name_for_log: user_name_for_log = user_profile_url.split('/')[-1]
-                except: pass
-
-                logger.info(f"--- ユーザー「{user_name_for_log}」(URL: {user_profile_url.split('/')[-1]}) の処理開始 ---")
-                processed_profile_urls.add(user_profile_url)
-                search_page_url_before_profile_visit = driver.current_url
-                driver.get(user_profile_url)
-                try:
-                    WebDriverWait(driver, 20).until(
-                        EC.all_of(
-                            EC.url_contains(user_profile_url.split('/')[-1]),
-                            EC.visibility_of_element_located((By.CSS_SELECTOR, "h1.css-jctfiw")),
-                            lambda d: d.execute_script("return document.readyState") == "complete",
-                            EC.presence_of_element_located((By.CSS_SELECTOR, "footer.css-1yg0z07"))
+            # --- ページネーション処理 (メインドライバー) ---
+            if page_num > 1:
+                logger.info(f"{page_num-1}ページ目({current_page_url_for_log})の処理完了。次のページ ({page_num}ページ目) へ遷移を試みます。")
+                next_button_selectors = [
+                    "a[data-testid='pagination-next-button']", "a[rel='next']", "a.next",
+                    "a.pagination__next", "button.next", "button.pagination__next",
+                    "a[aria-label*='次へ']:not([aria-disabled='true'])", "a[aria-label*='Next']:not([aria-disabled='true'])",
+                    "button[aria-label*='次へ']:not([disabled])", "button[aria-label*='Next']:not([disabled])"
+                ]
+                next_button_found = False
+                for selector in next_button_selectors:
+                    try:
+                        next_button = WebDriverWait(driver, 5).until(
+                            EC.element_to_be_clickable((By.CSS_SELECTOR, selector))
                         )
-                    )
+                        if next_button.is_displayed() and next_button.is_enabled():
+                            logger.info(f"「次へ」ボタンをセレクタ '{selector}' で発見。クリックします。")
+                            driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", next_button)
+                            time.sleep(0.5)
+                            next_button.click()
+                            next_button_found = True
+                            break
+                    except TimeoutException: logger.debug(f"セレクタ '{selector}' で「次へ」ボタンが見つからずタイムアウト。")
+                    except Exception as e_click: logger.warning(f"セレクタ '{selector}' でボタンクリック試行中にエラー: {e_click}")
+
+                if not next_button_found:
+                    logger.info("試行した全てのセレクタで、クリック可能な「次へ」ボタンが見つかりませんでした。検索結果のページネーション処理を終了します。")
+                    break # for page_num ループを抜ける
+                try:
+                    WebDriverWait(driver, 10).until(EC.url_changes(current_page_url_for_log)) # 前のページのURLと比較
+                    logger.info(f"{page_num}ページ目へ遷移しました。新しいURL: {driver.current_url}")
+                    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CSS_SELECTOR, activity_card_selector)))
+                    logger.info(f"{page_num}ページ目の活動記録カードの読み込みを確認。")
+                    time.sleep(delay_pagination)
                 except TimeoutException:
-                    logger.warning(f"ユーザープロフィールページ ({user_profile_url}) の読み込みタイムアウト（複合条件）。このユーザーの処理をスキップします。")
-                    driver.get(search_page_url_before_profile_visit)
-                    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CSS_SELECTOR, activity_card_selector)))
-                    continue
-                if user_profile_url not in driver.current_url:
-                    logger.error(f"URL不一致: プロフィールページ ({user_profile_url}) にいるはずが、現在のURLは {driver.current_url} です。スキップします。")
-                    driver.get(search_page_url_before_profile_visit)
-                    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CSS_SELECTOR, activity_card_selector)))
-                    continue
+                    logger.warning(f"{page_num}ページ目への遷移後、URL変化または活動記録カードの読み込みタイムアウト。処理を終了します。")
+                    break # for page_num ループを抜ける
+                except Exception as e_page_load:
+                    logger.error(f"{page_num}ページ目への遷移または読み込み中に予期せぬエラー: {e_page_load}", exc_info=True)
+                    break # for page_num ループを抜ける
 
-                follow_button_on_profile = find_follow_button_on_profile_page(driver)
-                if not follow_button_on_profile:
-                    logger.info(f"ユーザー「{user_name_for_log}」は既にフォロー済みか、プロフィールにフォローボタンがありません。スキップ。")
-                    driver.get(search_page_url_before_profile_visit)
-                    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CSS_SELECTOR, activity_card_selector)))
-                    continue
+            # 1ページ目のアクセス (driver.get はメインドライバーで行う)
+            if page_num == 1 and driver.current_url != start_url :
+                 logger.info(f"最初の活動記録検索結果 ({start_url}) にアクセスします。")
+                 driver.get(start_url)
+            try:
+                WebDriverWait(driver, 15).until(EC.presence_of_all_elements_located((By.CSS_SELECTOR, activity_card_selector)))
+            except TimeoutException:
+                page_identifier_for_log = start_url if page_num == 1 else driver.current_url
+                logger.warning(f"活動記録検索結果ページ ({page_identifier_for_log}) で活動記録カードの読み込みタイムアウト。このページの処理をスキップします。")
+                continue # 次の for page_num へ
 
-                follows, followers = get_user_follow_counts(driver, user_profile_url)
-                if follows == -1 or followers == -1:
-                    logger.warning(f"ユーザー「{user_name_for_log}」のフォロー数/フォロワー数が取得できませんでした。スキップ。")
-                    driver.get(search_page_url_before_profile_visit)
-                    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CSS_SELECTOR, activity_card_selector)))
-                    continue
-                if followers < min_followers:
-                    logger.info(f"ユーザー「{user_name_for_log}」のフォロワー数 ({followers}) が閾値 ({min_followers}) 未満。スキップ。")
-                    driver.get(search_page_url_before_profile_visit)
-                    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CSS_SELECTOR, activity_card_selector)))
-                    continue
+            initial_activity_cards_on_page = driver.find_elements(By.CSS_SELECTOR, activity_card_selector)
+            logger.info(f"{page_num}ページ目: {len(initial_activity_cards_on_page)} 件の活動記録候補を検出。")
+            if not initial_activity_cards_on_page:
+                logger.info("このページには活動記録が見つかりませんでした。")
+                continue # 次の for page_num へ
 
-                current_ratio = (follows / followers) if followers > 0 else float('inf')
-                logger.info(f"ユーザー「{user_name_for_log}」: F中={follows}, Fワー={followers}, Ratio={current_ratio:.2f} (閾値: >= {ratio_threshold})")
-                if not (current_ratio >= ratio_threshold):
-                    logger.info(f"Ratio ({current_ratio:.2f}) が閾値 ({ratio_threshold}) 未満です。スキップ。")
-                    driver.get(search_page_url_before_profile_visit)
-                    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CSS_SELECTOR, activity_card_selector)))
-                    continue
+            # --- ユーザー情報収集 (メインドライバー) ---
+            user_infos_for_tasks = []
+            for card_idx, card_element in enumerate(initial_activity_cards_on_page):
+                if len(user_infos_for_tasks) >= max_users_per_page : # このページで処理するユーザー数上限
+                    logger.info(f"このページでの処理対象ユーザー数上限 ({max_users_per_page}) に達したため、情報収集を停止。")
+                    break
 
-                logger.info(f"フォロー条件（Ratio >= {ratio_threshold}）を満たしました。ユーザー「{user_name_for_log}」をフォローします。")
-                if click_follow_button_and_verify(driver, follow_button_on_profile, user_name_for_log):
-                    total_followed_count += 1
-                    if domo_after_follow:
-                        logger.info(f"ユーザー「{user_name_for_log}」の最新活動記録にDOMOを試みます。")
-                        latest_act_url = get_latest_activity_url(driver, user_profile_url)
-                        if latest_act_url:
-                            if domo_activity(driver, latest_act_url, BASE_URL): # BASE_URL を渡す
-                                total_domoed_count += 1
-                        else:
-                            logger.info(f"ユーザー「{user_name_for_log}」の最新活動記録が見つからず、DOMOできませんでした。")
-                processed_users_on_current_page += 1
-                logger.info(f"--- ユーザー「{user_name_for_log}」の処理終了 ---")
-                logger.debug(f"ユーザー処理後、検索結果ページ ({search_page_url_before_profile_visit}) に戻ります。")
-                driver.get(search_page_url_before_profile_visit)
+                temp_user_profile_url = None
+                temp_user_name_for_log = f"活動記録{card_idx+1}のユーザー(P{page_num})"
                 try:
-                    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CSS_SELECTOR, activity_card_selector)))
-                except TimeoutException: logger.warning(f"検索結果ページ ({search_page_url_before_profile_visit}) に戻った後、活動記録カードの再表示タイムアウト。")
-                time.sleep(delay_user_processing)
-            except NoSuchElementException: logger.warning(f"活動記録カード {card_idx+1} からユーザー情報取得に必要な要素が見つかりません。スキップ。")
-            except Exception as e_user_proc:
-                logger.error(f"ユーザー「{user_name_for_log}」の処理中にエラー: {e_user_proc}", exc_info=True)
-                try:
-                    current_search_url_for_recovery = start_url if page_num == 1 else driver.current_url
-                    if driver.current_url != current_search_url_for_recovery:
-                         driver.get(current_search_url_for_recovery)
+                    # StaleElement対策のため、ループ内で毎回要素を再取得するのではなく、
+                    # initial_activity_cards_on_page から得た card_element を使う。
+                    # ただし、この card_element も後続のDOM変更でStaleになる可能性はあるが、
+                    # ここではURLと名前の取得のみに留める。
+                    profile_link_el = WebDriverWait(card_element, 5).until(
+                        EC.presence_of_element_located((By.CSS_SELECTOR, user_profile_link_in_card_selector))
+                    )
+                    href = profile_link_el.get_attribute("href")
+                    if href:
+                        if href.startswith("/"): temp_user_profile_url = BASE_URL + href
+                        elif href.startswith(BASE_URL): temp_user_profile_url = href
+
+                    if not temp_user_profile_url or f"/users/{current_user_id}" in temp_user_profile_url:
+                        logger.debug(f"無効なプロフィールURLか自分自身 ({temp_user_profile_url}) のためスキップ(情報収集時)。")
+                        continue
+                    if temp_user_profile_url in processed_profile_urls_session: # セッション全体での重複チェック
+                        logger.info(f"ユーザー ({temp_user_profile_url.split('/')[-1]}) はこのセッションで既に処理試行済みのためスキップ(情報収集時)。")
+                        continue
+
+                    try: # 名前取得はベストエフォート
+                        name_el = profile_link_el.find_element(By.CSS_SELECTOR, "span, img[alt]")
+                        if name_el.tag_name == "img": temp_user_name_for_log = name_el.get_attribute("alt")
+                        else: temp_user_name_for_log = name_el.text.strip()
+                        if not temp_user_name_for_log: temp_user_name_for_log = temp_user_profile_url.split('/')[-1]
+                    except: pass
+
+                    user_infos_for_tasks.append({"url": temp_user_profile_url, "name": temp_user_name_for_log})
+                    processed_profile_urls_session.add(temp_user_profile_url) # タスク投入（または逐次処理）決定なので、ここで処理済みに追加
+
+                except NoSuchElementException:
+                    logger.warning(f"活動記録カード {card_idx+1} (P{page_num}) からユーザー情報取得に必要な要素が見つかりません。スキップ(情報収集時)。")
+                except Exception as e_info_collect:
+                    logger.error(f"活動記録カード {card_idx+1} (P{page_num}) の情報収集中にエラー: {e_info_collect}", exc_info=True)
+
+            # --- タスク投入または逐次処理 ---
+            search_page_url_before_profile_visit_main = driver.current_url # 逐次処理で戻るためのURL
+            for user_info in user_infos_for_tasks:
+                if processed_users_on_current_page_count >= max_users_per_page: # 二重チェック
+                    break
+
+                if is_parallel_enabled and executor:
+                    logger.info(f"--- 並列タスク投入: ユーザー「{user_info['name']}」(URL: {user_info['url'].split('/')[-1]}) ---")
+                    future = executor.submit(_search_follow_domo_task, user_info['url'], user_info['name'], shared_cookies_from_main, sf_settings, ad_settings, current_user_id)
+                    futures_this_page.append(future)
+                else: # 逐次処理
+                    logger.info(f"--- 逐次処理開始: ユーザー「{user_info['name']}」(URL: {user_info['url'].split('/')[-1]}) ---")
+                    # メインドライバーで直接処理
+                    driver.get(user_info['url']) # プロフィールページへ
+                    try:
+                        WebDriverWait(driver, 20).until(
+                            EC.all_of(
+                                EC.url_contains(user_info['url'].split('/')[-1]),
+                                EC.visibility_of_element_located((By.CSS_SELECTOR, "h1.css-jctfiw")),
+                                lambda d: d.execute_script("return document.readyState") == "complete",
+                                EC.presence_of_element_located((By.CSS_SELECTOR, "footer.css-1yg0z07"))
+                            )
+                        )
+                    except TimeoutException:
+                        logger.warning(f"ユーザー「{user_info['name']}」プロフィールページ読み込みタイムアウト（逐次）。スキップ。")
+                        driver.get(search_page_url_before_profile_visit_main) # 検索結果ページに戻る
+                        WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CSS_SELECTOR, activity_card_selector)))
+                        continue # 次のユーザーへ
+
+                    if user_info['url'] not in driver.current_url:
+                         logger.error(f"URL不一致(逐次): プロフィールページ ({user_info['url']}) にいるはずが {driver.current_url} 。スキップ。")
+                         driver.get(search_page_url_before_profile_visit_main)
                          WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CSS_SELECTOR, activity_card_selector)))
-                except Exception as e_recover: logger.error(f"エラー後の検索ページ復帰試行中にもエラー: {e_recover}")
-        logger.info(f"{page_num}ページ目の処理が完了しました。")
-    logger.info(f"<<< 検索からのフォロー＆DOMO機能完了。合計フォロー: {total_followed_count}人, 合計DOMO: {total_domoed_count}件。")
+                         continue
+
+                    follow_button_seq = find_follow_button_on_profile_page(driver)
+                    if not follow_button_seq:
+                        logger.info(f"ユーザー「{user_info['name']}」は既にフォロー済みかボタンなし（逐次）。スキップ。")
+                    else:
+                        follows_seq, followers_seq = get_user_follow_counts(driver, user_info['url'])
+                        if follows_seq != -1 and followers_seq != -1 and followers_seq >= min_followers_seq:
+                            current_ratio_seq = (follows_seq / followers_seq) if followers_seq > 0 else float('inf')
+                            if current_ratio_seq >= ratio_threshold_seq:
+                                logger.info(f"ユーザー「{user_info['name']}」フォロー条件合致（逐次）。フォローします。")
+                                if click_follow_button_and_verify(driver, follow_button_seq, user_info['name']):
+                                    total_followed_count_session += 1
+                                    if domo_after_follow_seq:
+                                        logger.info(f"ユーザー「{user_info['name']}」最新活動記録DOMO試行（逐次）。")
+                                        latest_act_url_seq = get_latest_activity_url(driver, user_info['url'])
+                                        if latest_act_url_seq:
+                                            if domo_activity(driver, latest_act_url_seq, BASE_URL):
+                                                total_domoed_count_session += 1
+                                        else: logger.info(f"ユーザー「{user_info['name']}」最新活動記録なし（逐次）。")
+                            else: logger.info(f"ユーザー「{user_info['name']}」Ratio不足（逐次）。")
+                        else: logger.info(f"ユーザー「{user_info['name']}」フォロワー数不足または取得失敗（逐次）。")
+
+                    logger.info(f"--- ユーザー「{user_info['name']}」の逐次処理終了 ---")
+                    driver.get(search_page_url_before_profile_visit_main) # 検索結果ページに戻る
+                    try:
+                        WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.CSS_SELECTOR, activity_card_selector)))
+                    except TimeoutException: logger.warning(f"検索結果ページ ({search_page_url_before_profile_visit_main}) への復帰後、カード再表示タイムアウト。")
+                    time.sleep(sequential_delay_user_processing) # 逐次処理のユーザー間遅延
+
+                processed_users_on_current_page_count +=1
+
+
+            # --- このページの並列タスク結果処理 (is_parallel_enabled の場合のみ) ---
+            if is_parallel_enabled and futures_this_page:
+                logger.info(f"{page_num}ページ目で投入された {len(futures_this_page)} 件の並列タスクの結果を処理します...")
+                for future_item in as_completed(futures_this_page):
+                    try:
+                        result = future_item.result()
+                        res_profile_url = result.get("profile_url", "不明なURL")
+                        res_user_name = res_profile_url.split('/')[-1] # 簡易表示
+                        if result.get("error"):
+                            logger.error(f"並列タスクエラー (ユーザー: {res_user_name}): {result['error']}")
+                        else:
+                            if result.get("skipped_reason"):
+                                logger.info(f"ユーザー「{res_user_name}」はスキップされました（並列タスク）理由: {result['skipped_reason']}")
+                            total_followed_count_session += result.get("followed", 0)
+                            total_domoed_count_session += result.get("domoed", 0)
+                            if result.get("followed",0) > 0 : logger.info(f"ユーザー「{res_user_name}」のフォローに成功（並列）。")
+                            if result.get("domoed",0) > 0 : logger.info(f"ユーザー「{res_user_name}」のDOMOに成功（並列）。")
+                    except Exception as e_future_res:
+                        logger.error(f"並列検索フォロータスクの結果取得/処理中にエラー: {e_future_res}", exc_info=True)
+
+            logger.info(f"{page_num}ページ目の処理が完了しました。")
+            # ページネーション後の遅延はループの先頭で次のページ読み込み後に行われる (delay_pagination)
+
+    logger.info(f"<<< 検索からのフォロー＆DOMO機能完了。セッション合計フォロー: {total_followed_count_session}人, セッション合計DOMO: {total_domoed_count_session}件。")
+
+
+# nullcontext for Python < 3.7
+try:
+    from contextlib import nullcontext
+except ImportError:
+    import contextlib
+    @contextlib.contextmanager
+    def nullcontext(enter_result=None):
+        yield enter_result

--- a/yamap_auto/yamap_auto_domo.py
+++ b/yamap_auto/yamap_auto_domo.py
@@ -204,9 +204,10 @@ if __name__ == "__main__":
                 # フォローバック機能
                 if FOLLOW_BACK_SETTINGS.get("enable_follow_back", False):
                     start_time = time.time()
-                    # TODO: フォローバック機能の並列化対応 (domo_timeline_activities_parallel と同様の構造で)
-                    logger.info("現時点ではフォローバック機能は並列化未対応のため、逐次実行します。")
-                    follow_back_users_new(driver, MY_USER_ID)
+                    # shared_cookies が取得できていればそれを渡し、並列処理を試みる
+                    # follow_back_users_new 内部で並列設定が無効、またはCookieがない場合は逐次処理にフォールバックされる
+                    logger.info("フォローバック機能呼び出し。並列処理は設定とCookieの有無に依存。")
+                    follow_back_users_new(driver, MY_USER_ID, shared_cookies_from_main=shared_cookies)
                     end_time = time.time()
                     logger.info(f"フォローバック機能の処理時間: {end_time - start_time:.2f}秒")
                 else:
@@ -229,9 +230,8 @@ if __name__ == "__main__":
                 # 検索結果からのフォロー＆DOMO機能
                 if SEARCH_AND_FOLLOW_SETTINGS.get("enable_search_and_follow", False):
                     start_time = time.time()
-                    # TODO: 検索からのフォロー＆DOMO機能の並列化対応
-                    logger.info("現時点では検索からのフォロー＆DOMO機能は並列化未対応のため、逐次実行します。")
-                    search_follow_and_domo_users(driver, MY_USER_ID)
+                    logger.info("検索結果からのフォロー＆DOMO機能呼び出し。並列処理は設定とCookieの有無に依存。")
+                    search_follow_and_domo_users(driver, MY_USER_ID, shared_cookies_from_main=shared_cookies)
                     end_time = time.time()
                     logger.info(f"検索結果からのフォロー＆DOMO機能の処理時間: {end_time - start_time:.2f}秒")
                 else:


### PR DESCRIPTION
フォローバック機能と検索結果からのフォロー＆DOMO機能について、
処理時間短縮のため並列処理に対応しました。

主な変更点:
- ThreadPoolExecutorを使用して、個々のユーザー処理や フォローバックアクションを並列実行するように変更。
- 各ワーカースレッドは独立したWebDriverインスタンスと 共有Cookieで動作し、StaleElement例外を回避。
- config.yamlに並列処理の有効化フラグ、最大ワーカー数、 タスク毎の遅延を設定する項目を追加。
  - `follow_back_settings`:
    - `enable_parallel_follow_back`
    - `max_workers_follow_back`
    - `delay_per_worker_action_sec`
  - `search_and_follow_settings`:
    - `enable_parallel_search_follow`
    - `max_workers_search_follow`
    - `delay_per_worker_user_processing_sec`
- メインスクリプト(yamap_auto_domo.py)から各機能呼び出し時に Cookie情報を渡すように修正。
- TASK_MANAGEMENT.mdを更新し、本変更内容を反映。

これにより、特に多数のユーザーを処理する際のパフォーマンス向上が期待されます。
ユーザーはconfig.yamlで並列処理の有効/無効やワーカー数を調整可能です。