### PR TITLE
Fix: 並列処理時のログイン復元失敗への対策

### DIFF
--- a/yamap_auto/follow_back_utils.py
+++ b/yamap_auto/follow_back_utils.py
@@ -278,6 +278,12 @@ def follow_back_users_new(driver, current_user_id, shared_cookies_from_main=None
 
                     # --- ここで逐次処理と並列処理の分岐 ---
                     if is_parallel_enabled and executor:
+                        # 新規追加: ワーカー起動前の遅延
+                        delay_before_start = fb_settings.get("delay_before_worker_start_sec", 0.5)
+                        if delay_before_start > 0 and len(futures) > 0: # 最初のタスク投入時は遅延させない場合もあるので len(futures) > 0 を追加検討
+                            logger.debug(f"次のワーカー起動前に {delay_before_start} 秒待機します...")
+                            time.sleep(delay_before_start)
+
                         # 並列処理: タスクを投入
                         logger.info(f"フォロワー「{user_name_main}」(URL: {profile_url_main.split('/')[-1]}) のフォローバックタスクを投入します...")
                         # fb_settings と action_delays をタスクに渡す


### PR DESCRIPTION
並列処理で起動したWebDriverがCookieによるログイン状態の復元に失敗する問題への対策として、以下の点を修正しました。

- Cookie設定処理の改善:
  - Cookieのドメイン属性が初期ページドメインやYAMAP関連ドメインと一致しない場合、ドメイン情報を削除して設定を試みるフォールバック処理を追加。
  - Cookie追加試行エラー時にもドメイン削除して再試行する処理を追加。
- ログイン確認ロジックの改善:
  - 主要なログイン確認要素をプロフィール編集ボタンからヘッダーのユーザーメニューボタンに変更。
  - 待機条件を要素の可視性確認から存在確認に変更。
  - 従来の確認要素をフォールバックとして保持。
- デバッグ情報の拡充:
  - ログイン確認失敗時に、設定試行したCookieとWebDriverが実際に保持するCookieの詳細（valueを除く）をログに出力するよう変更。
- 並列処理の間隔調整:
  - 各ワーカースレッド起動前に設定可能な遅延を挿入するよう修正。
- User-Agentの統一:
  - WebDriverオプションで固定のUser-Agent文字列を設定するようにし、config.yamlから読み込むように変更。