### PR TITLE
Refactor: 活動日記取得処理を単純化し安定性を向上

### DIFF
--- a/yamap_auto/my_post_interaction_utils.py
+++ b/yamap_auto/my_post_interaction_utils.py
@@ -14,8 +14,8 @@ from selenium.common.exceptions import TimeoutException, NoSuchElementException
 from .driver_utils import get_main_config, BASE_URL, save_screenshot, create_driver_with_cookies
 from .user_profile_utils import get_latest_activity_url
 from .domo_utils import domo_activity
-from .follow_back_utils import _follow_back_task # フォローバック処理の一部を再利用検討
-from .follow_utils import find_follow_button_in_list_item, click_follow_button_and_verify # フォロー状態確認や実行に利用
+# from .follow_back_utils import _follow_back_task # フォローバック処理の一部を再利用検討 # 今回の修正では直接使わない
+from .follow_utils import find_follow_button_on_profile_page, click_follow_button_and_verify # 修正：find_follow_button_on_profile_page をインポート
 
 logger = logging.getLogger(__name__)
 
@@ -51,91 +51,70 @@ def get_my_activities_within_period(driver, user_profile_url, days_to_check):
     logger.info(f"過去{days_to_check}日間の自分の活動記録を取得します。プロフィールURL: {user_profile_url}")
     activities_within_period = []
 
-    current_url = driver.current_url
-    target_profile_page_url_base = user_profile_url.split('?')[0] # user_id部分のみ
-    activities_tab_url_part = "?tab=activities"
+    target_profile_page_url_base = user_profile_url.split('?')[0] # クエリパラメータを除いたベースURL
 
-    # ベースのプロフィールページにアクセスし、必要であれば活動日記タブに切り替え
-    if target_profile_page_url_base not in current_url:
-        logger.info(f"プロフィールページ ({target_profile_page_url_base}) にアクセスします。")
-        driver.get(target_profile_page_url_base)
-        WebDriverWait(driver, 15).until(EC.url_contains(target_profile_page_url_base.split('/')[-1]))
+    # ユーザーのプロフィールページにアクセス
+    # 現在のURLが既にターゲットのベースURLでない場合、または末尾のスラッシュの有無を考慮して判定
+    current_url_base = driver.current_url.split('?')[0].rstrip('/')
+    target_url_to_get = target_profile_page_url_base.rstrip('/')
 
-    if activities_tab_url_part not in driver.current_url:
-        activity_tab_selector = "a.UsersId__Tab__Link[href*='?tab=activities']"
+    if target_url_to_get != current_url_base:
+        logger.info(f"プロフィールページ ({target_url_to_get}) にアクセスします。")
+        driver.get(target_url_to_get) # URLの末尾スラッシュを統一
         try:
-            logger.info(f"活動日記タブ ({activity_tab_selector}) を探しています...")
-            activity_tab_link = WebDriverWait(driver, 10).until(
-                EC.element_to_be_clickable((By.CSS_SELECTOR, activity_tab_selector))
+            # URLがターゲットのベースURLで始まることを確認 (より柔軟なチェック)
+            # 例: https://yamap.com/users/123 や https://yamap.com/users/123?tab=activities などにマッチ
+            WebDriverWait(driver, 15).until(
+                EC.url_matches(f"^{target_url_to_get}(?:/|\\?.*)?$")
             )
-            # タブがアクティブでないことを確認するより確実な方法は、現在のURLを確認すること
-            # ただし、YAMAPのSPA実装によってはURLが即時変わらない可能性もあるため、
-            # ここではクラス属性の存在も補助的に確認するが、主に要素クリック後の待機に頼る
-            if "UsersId__Tab__Link--active" not in (activity_tab_link.get_attribute("class") or ""):
-                logger.info("活動日記タブに切り替えます...")
-                activity_tab_link.click()
-                # タブ切り替え後、リストコンテナが可視化され、最初のアイテムが表示されるまで待機
-                list_container_selector = "ul.UserActivityList__List"
-                first_list_item_selector = "li.UserActivityList__Item"
-                try:
-                    WebDriverWait(driver, 20).until( # タイムアウトを20秒に延長
-                        EC.visibility_of_element_located((By.CSS_SELECTOR, list_container_selector))
-                    )
-                    logger.info(f"リストコンテナ ({list_container_selector}) が表示されました。")
-                    # さらに、リスト内に最初のアイテムが表示されるまで待つことで、リスト内容の読み込みをより確実に待つ
-                    WebDriverWait(driver, 10).until( # リストアイテムの表示は追加で10秒待つ
-                        EC.presence_of_all_elements_located((By.CSS_SELECTOR, f"{list_container_selector} {first_list_item_selector}"))
-                    )
-                    logger.info(f"最初の活動記録アイテム ({first_list_item_selector}) の表示を確認しました。活動日記タブへの切り替え成功。")
-                except TimeoutException:
-                    logger.warning(f"活動日記タブクリック後、リストコンテナ ({list_container_selector}) または最初のアイテム ({first_list_item_selector}) の表示タイムアウト。スクリーンショットを保存します。")
-                    save_screenshot(driver, "ActivityListVisibilityTimeout", user_profile_url.split('/')[-1])
-                    # タイムアウトした場合、後続の処理で空のリストが返るため、ここでは早期リターンしない。
-                    # return activities_within_period # 必要に応じてリターン
-            else:
-                logger.info("既に活動日記タブが表示されているようです。")
-        except TimeoutException: # これは activity_tab_link の特定に関するタイムアウト
-            logger.warning(f"活動日記タブ ({activity_tab_selector}) の特定自体でタイムアウトしました。")
-            save_screenshot(driver, "ActivityTabFindFail", user_profile_url.split('/')[-1])
-            return activities_within_period
-        except Exception as e_tab_switch:
-            logger.error(f"活動日記タブへの切り替えまたは確認中に予期せぬエラー: {e_tab_switch}", exc_info=True)
-            save_screenshot(driver, "ActivityTabSwitchError", user_profile_url.split('/')[-1])
+            logger.info(f"プロフィールページ ({target_url_to_get}) の読み込みを確認しました。")
+        except TimeoutException:
+            logger.warning(f"プロフィールページ ({target_url_to_get}) の読み込み確認タイムアウト。")
+            save_screenshot(driver, "ProfilePageLoadTimeout", target_url_to_get.split('/')[-1])
             return activities_within_period
     else:
-        logger.info("既に活動日記タブのURLです。")
+        logger.info(f"既にプロフィールページ ({target_url_to_get}) または互換URLに滞在中です。")
 
-    # 活動記録一覧が表示されるまで待機 (ユーザー提供HTMLに基づく)
-    # 上のタブ切り替え成功時にリストの表示確認は既に行っているため、
-    # ここでの待機は、URL直打ちで来た場合や、タブが最初からアクティブだった場合をカバーする。
+    # 活動記録一覧が直接表示されていることを期待して待機
     activity_list_container_selector = "ul.UserActivityList__List"
-    first_list_item_selector_for_direct_access = "li.UserActivityList__Item"
+    first_activity_item_selector = "li.UserActivityList__Item"
+
+    logger.info(f"活動記録リストコンテナ ({activity_list_container_selector}) の表示を待ちます...")
     try:
-        WebDriverWait(driver, 10).until(
+        WebDriverWait(driver, 20).until(
             EC.visibility_of_element_located((By.CSS_SELECTOR, activity_list_container_selector))
         )
-        WebDriverWait(driver, 5).until(
-             EC.presence_of_all_elements_located((By.CSS_SELECTOR, f"{activity_list_container_selector} {first_list_item_selector_for_direct_access}"))
-        )
-        logger.info(f"プロフィールページで活動記録リストコンテナ ({activity_list_container_selector}) と最初のアイテムの表示を確認しました。")
-    except TimeoutException:
-        logger.warning(f"プロフィールページで活動記録リストコンテナ ({activity_list_container_selector}) または最初のアイテムの読み込みタイムアウト (10+5秒)。")
-        save_screenshot(driver, "ActivityListContainerTimeoutOnDirect", user_profile_url.split('/')[-1])
-        return activities_within_period
+        logger.info(f"活動記録リストコンテナ ({activity_list_container_selector}) が表示されました。")
 
-    # 活動記録アイテムのセレクタ (日付とリンクを含む) - ユーザー提供HTMLに基づき更新
+        logger.info(f"リスト内の最初の活動記録アイテム ({first_activity_item_selector}) の表示を待ちます...")
+        WebDriverWait(driver, 10).until(
+            EC.presence_of_all_elements_located((By.CSS_SELECTOR, first_activity_item_selector))
+        )
+        logger.info(f"最初の活動記録アイテム ({first_activity_item_selector}) の表示を確認しました。")
+
+    except TimeoutException:
+        logger.warning(f"活動記録リストコンテナまたは最初のアイテムの表示タイムアウト (最大30秒)。リストが空であるか、ページの読み込みに問題がある可能性があります。")
+        save_screenshot(driver, "ActivityListOrItemTimeout", target_url_to_get.split('/')[-1])
+        # 処理は継続し、後続の find_elements が空リストを返すのに任せる
+
     activity_item_selector = "li.UserActivityList__Item"
-    # activity_item_selector_article_check = "article.ActivityItem" # li の中に article があることを確認するための補助
     activity_link_selector = "a.ActivityItem__Link"
     activity_date_selector = "span.ActivityItem__Date"
 
     try:
-        list_container = driver.find_element(By.CSS_SELECTOR, activity_list_container_selector)
+        list_container_elements = driver.find_elements(By.CSS_SELECTOR, activity_list_container_selector)
+        if not list_container_elements:
+            logger.warning(f"活動記録リストコンテナ ({activity_list_container_selector}) が見つかりませんでした。")
+            # スクリーンショットは ActivityListOrItemTimeout で撮られている可能性があるのでここでは不要かも
+            return activities_within_period
+
+        list_container = list_container_elements[0]
         activity_elements = list_container.find_elements(By.CSS_SELECTOR, activity_item_selector)
+
         logger.info(f"{len(activity_elements)} 件の活動記録をプロフィールから検出しました。")
 
         if not activity_elements:
-            logger.info("プロフィールに活動記録が見つかりませんでした。")
+            logger.info("プロフィールに活動記録が見つかりませんでした（リストは存在するがアイテムが0件）。")
             return activities_within_period
 
         cutoff_date = datetime.now() - timedelta(days=days_to_check)
@@ -144,8 +123,6 @@ def get_my_activities_within_period(driver, user_profile_url, days_to_check):
         for item_idx, item in enumerate(activity_elements):
             try:
                 date_element = item.find_element(By.CSS_SELECTOR, activity_date_selector)
-                date_element = item.find_element(By.CSS_SELECTOR, activity_date_selector)
-                # 日付取得ロジックの堅牢性向上
                 activity_date = None
                 date_str_iso = date_element.get_attribute("datetime")
                 date_str_text = date_element.text.strip()
@@ -156,19 +133,21 @@ def get_my_activities_within_period(driver, user_profile_url, days_to_check):
                         logger.debug(f"活動記録 {item_idx+1}: ISO日付 '{date_str_iso}' -> {activity_date.strftime('%Y-%m-%d')}")
                     except ValueError:
                         logger.warning(f"活動記録 {item_idx+1}: ISO日付形式 ({date_str_iso}) の解析に失敗。テキスト日付を試みます。")
+                        activity_date = None
 
-                if not activity_date and date_str_text: # ISO日付が取得できない、またはパース失敗した場合
+                if not activity_date and date_str_text:
                     try:
-                        activity_date = datetime.strptime(date_str_text, "%Y.%m.%d")
-                        logger.debug(f"活動記録 {item_idx+1}: テキスト日付 '{date_str_text}' -> {activity_date.strftime('%Y-%m-%d')}")
+                        date_text_main_part = date_str_text.split('(')[0]
+                        activity_date = datetime.strptime(date_text_main_part, "%Y.%m.%d")
+                        logger.debug(f"活動記録 {item_idx+1}: テキスト日付 '{date_str_text}' (解析対象: '{date_text_main_part}') -> {activity_date.strftime('%Y-%m-%d')}")
                     except ValueError:
                          logger.warning(f"活動記録 {item_idx+1}: テキスト日付形式 ({date_str_text}) も不明です。スキップします。")
-                         continue # このアイテムの処理をスキップ
-                elif not activity_date and not date_str_text: # 両方とも取得できない場合
+                         continue
+                elif not activity_date and not date_str_text:
                     logger.warning(f"活動記録 {item_idx+1}: 日付情報が取得できませんでした。スキップします。")
                     continue
 
-                if not activity_date: # activity_date が None のままならスキップ
+                if not activity_date:
                     logger.warning(f"活動記録 {item_idx+1}: 有効な日付が特定できませんでした。スキップします。")
                     continue
 
@@ -177,38 +156,45 @@ def get_my_activities_within_period(driver, user_profile_url, days_to_check):
                 if activity_date.date() >= cutoff_date.date():
                     activity_url = None
                     try:
-                        link_element = item.find_element(By.CSS_SELECTOR, activity_link_selector)
-                        activity_url_path = link_element.get_attribute("href")
-                        if activity_url_path:
-                            if activity_url_path.startswith("/"):
-                                activity_url = BASE_URL + activity_url_path
-                            elif activity_url_path.startswith(BASE_URL): # フルURLの場合
-                                activity_url = activity_url_path
+                        link_elements = item.find_elements(By.CSS_SELECTOR, activity_link_selector)
+                        if link_elements:
+                            activity_url_path = link_elements[0].get_attribute("href")
+                            if activity_url_path:
+                                if activity_url_path.startswith("/"):
+                                    activity_url = BASE_URL + activity_url_path
+                                elif activity_url_path.startswith(BASE_URL):
+                                    activity_url = activity_url_path
 
-                            if activity_url and "/activities/" in activity_url:
-                                logger.info(f"  対象期間内の活動記録を発見: {activity_url.split('/')[-1]} (日付: {activity_date.strftime('%Y-%m-%d')})")
-                                activities_within_period.append(activity_url)
+                                if activity_url and "/activities/" in activity_url:
+                                    logger.info(f"  対象期間内の活動記録を発見: {activity_url.split('/')[-1].split('?')[0]} (日付: {activity_date.strftime('%Y-%m-%d')})")
+                                    activities_within_period.append(activity_url)
+                                else:
+                                    logger.warning(f"  取得したURLが無効か、活動記録ではありません: {activity_url_path}。アイテム {item_idx+1}")
                             else:
-                                logger.warning(f"  取得したURLが無効か、活動記録ではありません: {activity_url_path}。アイテム {item_idx+1}")
+                                logger.warning(f"  活動記録アイテム {item_idx+1}: href属性が空でした。({activity_link_selector})")
                         else:
-                            logger.warning(f"  活動記録アイテム {item_idx+1}: href属性が空でした。")
-                    except NoSuchElementException:
-                        logger.warning(f"  活動記録アイテム {item_idx+1}: リンク要素 ({activity_link_selector}) が見つかりません。")
+                            logger.warning(f"  活動記録アイテム {item_idx+1}: リンク要素 ({activity_link_selector}) が見つかりません。")
+                    except NoSuchElementException: # Should not happen with find_elements
+                        logger.warning(f"  活動記録アイテム {item_idx+1}: リンク要素 ({activity_link_selector}) の取得で予期せぬエラー。")
                 else:
-                    activity_id_log = "不明"
-                    if activity_url and "/activities/" in activity_url : activity_id_log = activity_url.split('/')[-1]
-                    elif 'activity_url_path' in locals() and activity_url_path and "/activities/" in activity_url_path: activity_id_log = activity_url_path.split('/')[-1]
-                    else: activity_id_log = f"アイテムインデックス {item_idx+1}"
+                    log_activity_id = f"アイテムインデックス {item_idx+1}"
+                    try:
+                        temp_link_elements = item.find_elements(By.CSS_SELECTOR, "a[href*='/activities/']")
+                        if temp_link_elements:
+                            temp_href = temp_link_elements[0].get_attribute("href")
+                            if temp_href and "/activities/" in temp_href:
+                                log_activity_id = temp_href.split('/')[-1].split('?')[0]
+                    except: pass
 
-                    logger.info(f"活動記録 {activity_id_log} (日付: {activity_date.strftime('%Y-%m-%d')}) は対象期間外です。これ以降の投稿も期間外とみなし処理を終了。")
+                    logger.info(f"活動記録 {log_activity_id} (日付: {activity_date.strftime('%Y-%m-%d')}) は対象期間外です。これ以降の投稿も期間外とみなし処理を終了。")
                     break
-            except NoSuchElementException as e_nse:
-                logger.warning(f"活動記録アイテム {item_idx+1} 内で必須要素 (日付等) が見つかりません: {e_nse}。スキップします。")
-            except Exception as e_item:
-                logger.error(f"活動記録アイテム {item_idx+1} の処理中に予期せぬエラー: {e_item}", exc_info=True)
+            except NoSuchElementException as e_nse_item:
+                logger.warning(f"活動記録アイテム {item_idx+1} 内で必須要素 (日付等) が見つかりません: {e_nse_item}。スキップします。")
+            except Exception as e_item_process:
+                logger.error(f"活動記録アイテム {item_idx+1} の処理中に予期せぬエラー: {e_item_process}", exc_info=True)
 
-    except Exception as e_list:
-        logger.error(f"活動記録リストの処理中に予期せぬエラー: {e_list}", exc_info=True)
+    except Exception as e_outer_list:
+        logger.error(f"活動記録リストの処理のどこかで予期せぬエラー: {e_outer_list}", exc_info=True)
 
     logger.info(f"取得した対象期間内の活動記録URL数: {len(activities_within_period)} 件")
     return activities_within_period
@@ -224,8 +210,8 @@ def get_domo_users_from_activity(driver, activity_url):
     Returns:
         list[dict]: DOMOしたユーザーの情報のリスト。各辞書は {'name': str, 'profile_url': str} を含む。
     """
-    domo_page_url = activity_url.split('?')[0] + "/domos" # クエリパラメータを除去して /domos を追加
-    logger.info(f"活動記録 ({activity_url.split('/')[-1]}) のDOMOユーザー一覧ページへアクセス: {domo_page_url}")
+    domo_page_url = activity_url.split('?')[0] + "/domos"
+    logger.info(f"活動記録 ({activity_url.split('/')[-1].split('?')[0]}) のDOMOユーザー一覧ページへアクセス: {domo_page_url}")
     domo_users = []
 
     driver.get(domo_page_url)
@@ -233,15 +219,13 @@ def get_domo_users_from_activity(driver, activity_url):
         WebDriverWait(driver, 10).until(EC.url_contains("/domos"))
     except TimeoutException:
         logger.error(f"DOMO一覧ページ ({domo_page_url}) への遷移確認タイムアウト。")
-        save_screenshot(driver, "DomoListPageLoadFail", activity_url.split('/')[-1])
+        save_screenshot(driver, "DomoListPageLoadFail", activity_url.split('/')[-1].split('?')[0])
         return domo_users
 
-    # DOMOユーザーリストのコンテナセレクタ (YAMAPのUIにより調整が必要)
-    # 例: ユーザーカードが並ぶ ul 要素など
-    user_list_container_selector = "ul[class*='UserList_list']" # 仮のセレクタ
-    user_card_selector = "li[class*='UserListItem_container']" # 仮のユーザーカードセレクタ
-    user_name_selector = "h2[class*='UserListItem_name']" # 仮のユーザー名セレクタ
-    user_link_selector = "a[class*='UserListItem_avatarLink']" # 仮のプロフィールリンクセレクタ (アバター画像などから)
+    user_list_container_selector = "ul[class*='UserList_list']"
+    user_card_selector = "li[class*='UserListItem_container']"
+    user_name_selector = "h2[class*='UserListItem_name']"
+    user_link_selector = "a[class*='UserListItem_avatarLink']"
 
     page_num = 1
     while True:
@@ -255,13 +239,13 @@ def get_domo_users_from_activity(driver, activity_url):
             logger.warning(f"DOMOユーザーリストコンテナの読み込みタイムアウト (ページ {page_num})。")
             break
 
-        time.sleep(1.0) # リスト内容の描画待ち
+        time.sleep(1.0)
 
         user_elements = driver.find_elements(By.CSS_SELECTOR, user_card_selector)
         if not user_elements:
             logger.info(f"ページ {page_num} にDOMOユーザーが見つかりませんでした。")
-            if page_num == 1: # 最初のページに誰もいなければDOMOなしと判断
-                logger.info(f"活動記録 ({activity_url.split('/')[-1]}) にDOMOユーザーはいません。")
+            if page_num == 1:
+                logger.info(f"活動記録 ({activity_url.split('/')[-1].split('?')[0]}) にDOMOユーザーはいません。")
             break
 
         logger.info(f"{len(user_elements)} 件のDOMOユーザー候補をページ {page_num} で検出。")
@@ -272,7 +256,10 @@ def get_domo_users_from_activity(driver, activity_url):
                 profile_url = link_el.get_attribute("href")
                 if profile_url:
                     if profile_url.startswith("/"):
-                        profile_url = BASE_URL + profile_url
+                        profile_url = BASE_URL + profile_url.split('?')[0] # クエリパラメータを除去
+                    else:
+                        profile_url = profile_url.split('?')[0] # クエリパラメータを除去
+
                     if "/users/" in profile_url:
                         domo_users.append({"name": name, "profile_url": profile_url})
                         logger.debug(f"  DOMOユーザー発見: {name} ({profile_url})")
@@ -283,8 +270,7 @@ def get_domo_users_from_activity(driver, activity_url):
             except Exception as e_user_parse:
                 logger.error(f"DOMOユーザー情報の解析中にエラー: {e_user_parse}", exc_info=True)
 
-        # 次へボタンの処理 (YAMAPのUIにより調整が必要)
-        next_button_selector = "button[aria-label='次のページに移動する']:not([disabled])" # 仮
+        next_button_selector = "button[aria-label='次のページに移動する']:not([disabled])"
         try:
             next_button = driver.find_element(By.CSS_SELECTOR, next_button_selector)
             if next_button.is_displayed() and next_button.is_enabled():
@@ -293,7 +279,7 @@ def get_domo_users_from_activity(driver, activity_url):
                 time.sleep(0.5)
                 next_button.click()
                 page_num += 1
-                time.sleep(2.0) # ページ遷移後の安定待ち
+                time.sleep(2.0)
             else:
                 logger.info("「次へ」ボタンが無効または非表示です。最終ページと判断。")
                 break
@@ -304,7 +290,7 @@ def get_domo_users_from_activity(driver, activity_url):
             logger.error(f"「次へ」ボタン処理中にエラー: {e_next}", exc_info=True)
             break
 
-    logger.info(f"活動記録 ({activity_url.split('/')[-1]}) から合計 {len(domo_users)} 件のDOMOユーザー情報を取得しました。")
+    logger.info(f"活動記録 ({activity_url.split('/')[-1].split('?')[0]}) から合計 {len(domo_users)} 件のDOMOユーザー情報を取得しました。")
     return domo_users
 
 
@@ -315,13 +301,12 @@ def interact_with_domo_users_on_my_posts(driver, current_user_id, shared_cookies
     mpi_settings = _get_my_post_interaction_settings()
     if not mpi_settings.get("enable_my_post_interaction", False):
         logger.info("自分の投稿へのDOMOユーザーインタラクション機能は無効です。")
-        return 0, 0 # followed_count, domoed_count
+        return 0, 0
 
     logger.info(">>> 自分の投稿へのDOMOユーザーインタラクション機能を開始します...")
     days_to_check = mpi_settings.get("max_days_to_check_my_posts", 7)
     my_profile_url = f"{BASE_URL}/users/{current_user_id}"
 
-    # 1. 自分の対象期間内の活動記録URLを取得
     my_activities = get_my_activities_within_period(driver, my_profile_url, days_to_check)
     if not my_activities:
         logger.info("対象期間内に処理すべき自分の活動記録が見つかりませんでした。")
@@ -330,48 +315,35 @@ def interact_with_domo_users_on_my_posts(driver, current_user_id, shared_cookies
     total_followed_back_count = 0
     total_domoed_to_users_count = 0
 
-    # フォローバックに関する設定 (既存のものを流用)
     fb_settings_for_interaction = _get_follow_back_settings_for_interaction()
     action_delays = _get_config_cached().get("action_delays", {})
-
-    processed_user_interactions_this_session = set() # (user_profile_url, interaction_type) のタプルを記録
+    processed_user_interactions_this_session = set()
 
     for activity_url in my_activities:
-        logger.info(f"--- 活動記録 ({activity_url.split('/')[-1]}) のDOMOユーザーへのインタラクションを開始 ---")
-
-        # 2. 当該活動記録のDOMOユーザーリストを取得
-        #    DOMOユーザーリスト取得はメインドライバーで行う
+        activity_id_log = activity_url.split('/')[-1].split('?')[0]
+        logger.info(f"--- 活動記録 ({activity_id_log}) のDOMOユーザーへのインタラクションを開始 ---")
         domo_users = get_domo_users_from_activity(driver, activity_url)
         if not domo_users:
-            logger.info(f"活動記録 ({activity_url.split('/')[-1]}) にDOMOユーザーがいませんでした。")
+            logger.info(f"活動記録 ({activity_id_log}) にDOMOユーザーがいませんでした。")
             continue
 
         for domo_user in domo_users:
             user_name = domo_user["name"]
-            user_profile_url = domo_user["profile_url"]
+            user_profile_url = domo_user["profile_url"] # 既にクエリ除去済みのはず
             user_id_short = user_profile_url.split('/')[-1]
 
-            if user_profile_url == my_profile_url:
+            if user_id_short == str(current_user_id): # 自分自身はスキップ
                 logger.debug(f"DOMOユーザー ({user_name}) は自分自身なのでスキップします。")
                 continue
 
-            # a. フォローバック処理
-            #    ここでは _follow_back_task を直接呼び出すのではなく、
-            #    メインドライバーで相手のプロフィールページにアクセスし、フォロー状態を確認・実行する方式を採用。
-            #    これは _follow_back_task が別スレッドでの動作を前提としているため。
             if (user_profile_url, 'follow_back') not in processed_user_interactions_this_session:
                 logger.info(f"DOMOユーザー ({user_name}, {user_id_short}) のフォロー状態を確認・試行します。")
-                driver.get(user_profile_url)
+                driver.get(user_profile_url) # 相手のプロフィールページへ
                 try:
                     WebDriverWait(driver, 10).until(EC.url_contains(user_id_short))
-                    # プロフィールページでフォローボタンを探す
                     follow_button_on_profile = find_follow_button_on_profile_page(driver)
                     if follow_button_on_profile:
                         logger.info(f"ユーザー ({user_name}) はまだフォローしていません。フォローバックを試みます。")
-                        # フォロー条件の判定 (既存の follow_back_settings に基づく)
-                        # ここでは簡略化のため、レシオ等の詳細な条件判定は省略し、
-                        # 「フォローボタンがあればフォローする」という動作にする。
-                        # 必要であれば、get_user_follow_counts 等で情報を取得し判定ロジックを追加。
                         if click_follow_button_and_verify(driver, follow_button_on_profile, user_name):
                             total_followed_back_count += 1
                             logger.info(f"ユーザー ({user_name}) のフォローバックに成功しました。")
@@ -383,33 +355,40 @@ def interact_with_domo_users_on_my_posts(driver, current_user_id, shared_cookies
                     processed_user_interactions_this_session.add((user_profile_url, 'follow_back'))
                 except TimeoutException:
                     logger.error(f"ユーザー ({user_name}) のプロフィールページ ({user_profile_url}) 読み込みタイムアウト。フォローバック処理スキップ。")
+                    save_screenshot(driver, f"FollowBackProfileLoadTimeout_{user_id_short}")
                 except Exception as e_fb:
                     logger.error(f"ユーザー ({user_name}) のフォローバック処理中にエラー: {e_fb}", exc_info=True)
+                    save_screenshot(driver, f"FollowBackError_{user_id_short}")
             else:
                 logger.info(f"ユーザー ({user_name}) のフォローバックは既に試行済みです。")
 
-
-            # b. 最新投稿へのDOMO処理
-            if (user_profile_url, 'domo_latest') not in processed_user_interactions_this_session:
-                logger.info(f"DOMOユーザー ({user_name}, {user_id_short}) の最新活動記録へのDOMOを試みます。")
-                # 最新活動記録URLを取得 (相手のプロフィールページにいるはずなので、driverをそのまま使用)
-                latest_activity_url = get_latest_activity_url(driver, user_profile_url) # この関数は内部でページ遷移する場合あり
-                if latest_activity_url:
-                    logger.info(f"ユーザー ({user_name}) の最新活動記録URL: {latest_activity_url}")
-                    if domo_activity(driver, latest_activity_url): # この関数も内部でページ遷移する場合あり
-                        total_domoed_to_users_count += 1
-                        logger.info(f"ユーザー ({user_name}) の最新活動記録へのDOMOに成功しました。")
+            if mpi_settings.get("enable_domo_to_latest_activity", True): # 設定でDOMO返しを制御
+                if (user_profile_url, 'domo_latest') not in processed_user_interactions_this_session:
+                    logger.info(f"DOMOユーザー ({user_name}, {user_id_short}) の最新活動記録へのDOMOを試みます。")
+                    # 最新活動記録URLを取得するためには、再度相手のプロフィールページにいる必要がある。
+                    # フォローバック処理で既にそのページにいるはずだが、念のため driver.get(user_profile_url) を実行しても良い。
+                    # ただし、get_latest_activity_url が内部でページ遷移を伴う場合があるので注意。
+                    # ここでは、前のフォローバック処理で相手のプロフィールページにいることを期待。
+                    latest_activity_url = get_latest_activity_url(driver, user_profile_url) # この関数は相手のプロフィールページで実行される想定
+                    if latest_activity_url:
+                        logger.info(f"ユーザー ({user_name}) の最新活動記録URL: {latest_activity_url.split('?')[0]}")
+                        if domo_activity(driver, latest_activity_url):
+                            total_domoed_to_users_count += 1
+                            logger.info(f"ユーザー ({user_name}) の最新活動記録へのDOMOに成功しました。")
+                        else:
+                            logger.info(f"ユーザー ({user_name}) の最新活動記録へのDOMOはスキップまたは失敗しました。")
                     else:
-                        logger.info(f"ユーザー ({user_name}) の最新活動記録へのDOMOはスキップまたは失敗しました。")
+                        logger.info(f"ユーザー ({user_name}) の最新活動記録が見つかりませんでした。")
+                    processed_user_interactions_this_session.add((user_profile_url, 'domo_latest'))
                 else:
-                    logger.info(f"ユーザー ({user_name}) の最新活動記録が見つかりませんでした。")
-                processed_user_interactions_this_session.add((user_profile_url, 'domo_latest'))
+                    logger.info(f"ユーザー ({user_name}) の最新投稿へのDOMOは既に試行済みです。")
             else:
-                logger.info(f"ユーザー ({user_name}) の最新投稿へのDOMOは既に試行済みです。")
+                logger.info(f"DOMOユーザー ({user_name}) の最新活動記録へのDOMOは設定で無効です。")
 
-            time.sleep(mpi_settings.get("delay_between_user_interaction_sec", 3.0)) # ユーザー間の処理遅延
 
-        logger.info(f"--- 活動記録 ({activity_url.split('/')[-1]}) のDOMOユーザーへのインタラクションを終了 ---")
+            time.sleep(mpi_settings.get("delay_between_user_interaction_sec", 3.0))
+
+        logger.info(f"--- 活動記録 ({activity_id_log}) のDOMOユーザーへのインタラクションを終了 ---")
 
     logger.info(f"<<< 自分の投稿へのDOMOユーザーインタラクション機能完了。")
     logger.info(f"  合計フォローバック数: {total_followed_back_count}")


### PR DESCRIPTION
ユーザープロファイルページ表示時に既に活動日記が表示されている
状況に対応するため、my_post_interaction_utils.get_my_activities_within_period 関数内の活動日記タブへの明示的な切り替え処理を削除。

変更点：
- プロフィールページアクセス後、直接活動記録リストの表示を待つように変更。
- これにより、冗長なタブ操作処理を排除し、処理を単純化。
- 待機処理にはEC.visibility_of_element_locatedと EC.presence_of_all_elements_locatedを使用し、堅牢性を維持。
- 関連するURL比較ロジックやログ出力を調整。

この変更により、特定環境で発生していたタブ切り替え時のタイムアウト警告の
根本的な解消と、処理の安定性向上が期待される。