### PR TITLE
fix: フォロー/フォロワーリスト取得のCSSセレクタを修正

### DIFF
--- a/TASK_MANAGEMENT.md
+++ b/TASK_MANAGEMENT.md
@@ -5,6 +5,8 @@
 ---
 
 ## 🛠 仕掛中タスク
+*   [ ] **修正:** `user_profile_utils.py` のフォロー中/フォロワーリスト取得機能におけるCSSセレクタをユーザー提供情報に基づき修正 (コミット: `[THIS_COMMIT_HASH]`)
+    *   対象セレクタ: `user_list_item_selector`, `user_profile_link_selector`, `next_page_button_selector`
 *   [ ] **新機能:** 自分自身の1週間以内の記事投稿について、DOMOをくれた未フォローユーザーをフォローバックし、そのユーザーの最新投稿1つへDOMOする機能 (コミット: `[PREVIOUS_COMMIT_HASH]`)
     *   `my_post_interaction_utils.py` に主要ロジックを実装。
     *   `yamap_auto_domo.py` から呼び出し、`config.yaml` に設定項目追加。

--- a/yamap_auto/user_profile_utils.py
+++ b/yamap_auto/user_profile_utils.py
@@ -463,11 +463,11 @@ def get_my_following_users_profiles(driver, my_user_id, max_users_to_fetch=None,
     processed_pages = 0
 
     # ユーザーリストアイテムとユーザーリンクのセレクタ (YAMAPのUIに依存)
-    user_list_item_selector = "div.UserListItem_userListItem__XXXXX" # 仮のセレクタ、実際のものに置き換える必要あり
-    user_profile_link_selector = "a[href*='/users/']" # アイテム内のユーザープロファイルへのリンク
+    user_list_item_selector = "li.UserFollowList__Item" # ユーザー提供情報に基づき修正
+    user_profile_link_selector = "div.UserItem a[href^='/users/']" # ユーザー提供情報に基づき修正
 
     # 「次へ」ボタンのセレクタ (YAMAPのUIに依存)
-    next_page_button_selector = "button[data-testid='pagination-next-button']" # 仮のセレクタ
+    next_page_button_selector = "button.btn-next" # ユーザー提供情報に基づき修正
 
     while True:
         if max_pages_to_check is not None and processed_pages >= max_pages_to_check:
@@ -569,9 +569,9 @@ def get_my_followers_profiles(driver, my_user_id, max_users_to_fetch=None, max_p
 
     user_profile_urls = []
     processed_pages = 0
-    user_list_item_selector = "div.UserListItem_userListItem__XXXXX" # 仮のセレクタ
-    user_profile_link_selector = "a[href*='/users/']"
-    next_page_button_selector = "button[data-testid='pagination-next-button']" # 仮のセレクタ
+    user_list_item_selector = "li.UserFollowList__Item" # ユーザー提供情報に基づき修正
+    user_profile_link_selector = "div.UserItem a[href^='/users/']" # ユーザー提供情報に基づき修正
+    next_page_button_selector = "button.btn-next" # ユーザー提供情報に基づき修正
 
     while True:
         if max_pages_to_check is not None and processed_pages >= max_pages_to_check:


### PR DESCRIPTION
ユーザーから提供されたHTML情報に基づき、`user_profile_utils.py` 内の
`get_my_following_users_profiles` および `get_my_followers_profiles` 関数で 使用される以下のCSSセレクタを修正しました。

- `user_list_item_selector`: `li.UserFollowList__Item`
- `user_profile_link_selector`: `div.UserItem a[href^="/users/"]`
- `next_page_button_selector`: `button.btn-next`

これにより、フォロー中およびフォロワーのリスト取得とページネーションの
信頼性向上を期待します。