### PR TITLE
fix: フォロー/フォロワーリスト取得時のURL生成ロジックを修正

### DIFF
--- a/TASK_MANAGEMENT.md
+++ b/TASK_MANAGEMENT.md
@@ -5,7 +5,9 @@
 ---
 
 ## 🛠 仕掛中タスク
-*   [ ] **修正:** `user_profile_utils.py` のフォロー中/フォロワーリスト取得機能におけるCSSセレクタをユーザー提供情報に基づき修正 (コミット: `[THIS_COMMIT_HASH]`)
+*   [ ] **修正:** `user_profile_utils.py` のフォロー中/フォロワーリスト取得機能におけるURL生成ロジックを修正 (コミット: `[THIS_COMMIT_HASH]`)
+    *   URL末尾に `?tab=follows#tabs` または `?tab=followers#tabs` を追加。
+*   [ ] **修正:** `user_profile_utils.py` のフォロー中/フォロワーリスト取得機能におけるCSSセレクタをユーザー提供情報に基づき修正 (コミット: `[PREVIOUS_COMMIT_HASH]`)
     *   対象セレクタ: `user_list_item_selector`, `user_profile_link_selector`, `next_page_button_selector`
 *   [ ] **新機能:** 自分自身の1週間以内の記事投稿について、DOMOをくれた未フォローユーザーをフォローバックし、そのユーザーの最新投稿1つへDOMOする機能 (コミット: `[PREVIOUS_COMMIT_HASH]`)
     *   `my_post_interaction_utils.py` に主要ロジックを実装。

--- a/yamap_auto/user_profile_utils.py
+++ b/yamap_auto/user_profile_utils.py
@@ -449,7 +449,7 @@ def get_my_following_users_profiles(driver, my_user_id, max_users_to_fetch=None,
         logger.error("自分のユーザーIDが指定されていないため、フォロー中ユーザーリストを取得できません。")
         return []
 
-    following_list_url = f"{BASE_URL}/users/{my_user_id}/follows"
+    following_list_url = f"{BASE_URL}/users/{my_user_id}?tab=follows#tabs" # URL形式を修正
     logger.info(f"自分のフォロー中ユーザーリスト ({following_list_url}) からプロフィールURLを取得します。")
     logger.info(f"取得上限: ユーザー数={max_users_to_fetch or '無制限'}, ページ数={max_pages_to_check or '無制限'}")
 
@@ -556,7 +556,7 @@ def get_my_followers_profiles(driver, my_user_id, max_users_to_fetch=None, max_p
         logger.error("自分のユーザーIDが指定されていないため、フォロワーリストを取得できません。")
         return []
 
-    followers_list_url = f"{BASE_URL}/users/{my_user_id}/followers" # URLが異なる
+    followers_list_url = f"{BASE_URL}/users/{my_user_id}?tab=followers#tabs" # URL形式を修正
     logger.info(f"自分のフォロワーリスト ({followers_list_url}) からプロフィールURLを取得します。")
     logger.info(f"取得上限: ユーザー数={max_users_to_fetch or '無制限'}, ページ数={max_pages_to_check or '無制限'}")
 


### PR DESCRIPTION
ユーザーからの指摘に基づき、`user_profile_utils.py` 内の
`get_my_following_users_profiles` および `get_my_followers_profiles` 関数で 生成されるURLの末尾に `?tab=follows#tabs` または `?tab=followers#tabs` を 追加するように修正しました。

これにより、正しいフォロー中/フォロワーリストページにアクセスし、
リスト取得処理が正常に行われることを期待します。