### PR TITLE
fix: wait_for_page_transition 関数のロジックを改善

### DIFF
--- a/TASK_MANAGEMENT.md
+++ b/TASK_MANAGEMENT.md
@@ -5,7 +5,9 @@
 ---
 
 ## 🛠 仕掛中タスク
-*   [ ] **修正:** `user_profile_utils.py` のフォロー中/フォロワーリスト取得機能におけるURL生成ロジックを修正 (コミット: `[THIS_COMMIT_HASH]`)
+*   [ ] **修正:** `driver_utils.py` の `wait_for_page_transition` 関数の待機ロジックを改善 (コミット: `[THIS_COMMIT_HASH]`)
+    *   要素出現の待機を優先し、`driver.get()` 直後の呼び出しに対応。
+*   [ ] **修正:** `user_profile_utils.py` のフォロー中/フォロワーリスト取得機能におけるURL生成ロジックを修正 (コミット: `[PREVIOUS_COMMIT_HASH]`)
     *   URL末尾に `?tab=follows#tabs` または `?tab=followers#tabs` を追加。
 *   [ ] **修正:** `user_profile_utils.py` のフォロー中/フォロワーリスト取得機能におけるCSSセレクタをユーザー提供情報に基づき修正 (コミット: `[PREVIOUS_COMMIT_HASH]`)
     *   対象セレクタ: `user_list_item_selector`, `user_profile_link_selector`, `next_page_button_selector`


### PR DESCRIPTION
`driver_utils.py` 内の `wait_for_page_transition` 関数の 待機ロジックを以下のように改善しました。

- `expected_element_selector` が指定されている場合、その要素の出現を 主要な待機条件として優先的にチェックするように変更。
- `previous_url` および `expected_url_part` の条件も、要素出現の 条件と組み合わせて評価されるように調整。

これにより、特に `driver.get()` の直後にこの関数が呼び出された際に、
ページの要素が完全に読み込まれるまでより確実に待機できるようになることを
期待します。