### PR TITLE
fix: リスト取得時の待機対象セレクタを親要素に変更

### DIFF
--- a/TASK_MANAGEMENT.md
+++ b/TASK_MANAGEMENT.md
@@ -5,7 +5,9 @@
 ---
 
 ## 🛠 仕掛中タスク
-*   [ ] **修正:** `driver_utils.py` の `wait_for_page_transition` 関数の待機ロジックを改善 (コミット: `[THIS_COMMIT_HASH]`)
+*   [ ] **修正:** `user_profile_utils.py` の `wait_for_page_transition` 呼び出し時の待機対象セレクタを `ul.UserFollowList__List` に変更 (コミット: `[THIS_COMMIT_HASH]`)
+    *   リストアイテム個々ではなく、リスト全体を囲む要素の出現を待つように修正。
+*   [ ] **修正:** `driver_utils.py` の `wait_for_page_transition` 関数の待機ロジックを改善 (コミット: `[PREVIOUS_COMMIT_HASH]`)
     *   要素出現の待機を優先し、`driver.get()` 直後の呼び出しに対応。
 *   [ ] **修正:** `user_profile_utils.py` のフォロー中/フォロワーリスト取得機能におけるURL生成ロジックを修正 (コミット: `[PREVIOUS_COMMIT_HASH]`)
     *   URL末尾に `?tab=follows#tabs` または `?tab=followers#tabs` を追加。

--- a/yamap_auto/user_profile_utils.py
+++ b/yamap_auto/user_profile_utils.py
@@ -461,8 +461,8 @@ def get_my_following_users_profiles(driver, my_user_id, max_users_to_fetch=None,
 
     current_url_before_get = driver.current_url
     driver.get(following_list_url)
-    # ページ遷移とリスト表示の待機 (URL変更とリストアイテムの出現を期待)
-    wait_for_page_transition(driver, timeout=15, expected_element_selector=(By.CSS_SELECTOR, user_list_item_selector), previous_url=current_url_before_get if current_url_before_get != following_list_url else None)
+    # ページ遷移とリスト表示の待機 (ul.UserFollowList__List の出現を期待)
+    wait_for_page_transition(driver, timeout=30, expected_element_selector=(By.CSS_SELECTOR, "ul.UserFollowList__List"), previous_url=current_url_before_get if current_url_before_get != following_list_url else None)
 
 
     user_profile_urls = []
@@ -568,8 +568,8 @@ def get_my_followers_profiles(driver, my_user_id, max_users_to_fetch=None, max_p
     # 以降のロジックは get_my_following_users_profiles とほぼ同じ
     current_url_before_get = driver.current_url
     driver.get(followers_list_url)
-    # ページ遷移とリスト表示の待機 (URL変更とリストアイテムの出現を期待)
-    wait_for_page_transition(driver, timeout=15, expected_element_selector=(By.CSS_SELECTOR, user_list_item_selector), previous_url=current_url_before_get if current_url_before_get != followers_list_url else None)
+    # ページ遷移とリスト表示の待機 (ul.UserFollowList__List の出現を期待)
+    wait_for_page_transition(driver, timeout=30, expected_element_selector=(By.CSS_SELECTOR, "ul.UserFollowList__List"), previous_url=current_url_before_get if current_url_before_get != followers_list_url else None)
 
     user_profile_urls = []
     processed_pages = 0


### PR DESCRIPTION
`user_profile_utils.py` の `get_my_following_users_profiles` および `get_my_followers_profiles` 関数内で `wait_for_page_transition` を 呼び出す際に、期待する要素のセレクタを個々のリストアイテム
(`li.UserFollowList__Item`) から、リスト全体を囲む親要素
(`ul.UserFollowList__List`) に変更しました。

これにより、ページの動的な読み込み時において、より安定して
リストコンテナの出現を待機し、その後のアイテム取得処理の
成功率向上を期待します。