### PR TITLE
fix: リスト取得時の待機処理とセレクタを修正

### DIFF
--- a/yamap_auto/user_profile_utils.py
+++ b/yamap_auto/user_profile_utils.py
@@ -615,10 +615,11 @@ def get_my_followers_profiles(driver, my_user_id, max_users_to_fetch=None, max_p
                 next_button = driver.find_element(By.CSS_SELECTOR, next_page_button_selector)
                 if next_button.is_displayed() and next_button.is_enabled():
                     logger.info("「次へ」ボタンをクリックします。")
+                    prev_url = driver.current_url
                     driver.execute_script("arguments[0].scrollIntoView(true);", next_button)
                     time.sleep(0.5)
                     next_button.click()
-                    wait_for_page_load(driver, timeout=10, check_title=False, previous_url=driver.current_url)
+                    wait_for_page_transition(driver, timeout=10, expected_element_selector=(By.CSS_SELECTOR, user_list_item_selector), previous_url=prev_url)
                     time.sleep(1)
                 else:
                     logger.info("「次へ」ボタンが見つからないか、無効です。最後のページと判断します。")


### PR DESCRIPTION
`user_profile_utils.py` のリスト取得関連処理を以下のように修正しました。

- `get_my_following_users_profiles` および `get_my_followers_profiles` 関数内で `wait_for_page_transition` を呼び出す際に、期待する要素のセレクタを 個々のリストアイテム (`li.UserFollowList__Item`) から、リスト全体を 囲む親要素 (`ul.UserFollowList__List`) に変更。
- 上記対応時に `get_my_followers_profiles` 関数内のページネーション処理で `wait_for_page_load` が残存していた箇所を `wait_for_page_transition` に修正。

これにより、ページの動的な読み込み時において、より安定して
リストコンテナの出現を待機し、その後のアイテム取得処理の
成功率向上を期待します。