### PR TITLE
Fix: Import as_completed in user_profile_utils

### DIFF
--- a/yamap_auto/user_profile_utils.py
+++ b/yamap_auto/user_profile_utils.py
@@ -20,7 +20,7 @@ from .driver_utils import get_main_config, BASE_URL, wait_for_page_transition, s
 
 # New imports
 from bs4 import BeautifulSoup
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Adds the missing `as_completed` import from `concurrent.futures` to resolve a NameError when using ThreadPoolExecutor for parsing user items.