### PR TITLE
Opt: Use last activity date from following list for unfollow check

### DIFF
--- a/yamap_auto/user_profile_utils.py
+++ b/yamap_auto/user_profile_utils.py
@@ -24,22 +24,37 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 logger = logging.getLogger(__name__)
 
+# Ensure datetime is imported from datetime
+from datetime import datetime
+
+# ... (logger definition) ...
+
 # Helper function to parse a single user item using BeautifulSoup
 def _parse_user_item_bs(item_html_content):
     """
     Parses a single user list item's HTML (obtained via BeautifulSoup)
-    to extract profile URL, name, and follow-back status.
+    to extract profile URL, name, follow-back status, and last activity date from the list item.
     """
     item_soup = BeautifulSoup(item_html_content, 'html.parser')
 
     profile_url = "N/A"
     user_name = "N/A"
     is_followed_back = False
+    last_activity_date_on_list = None # New field
 
     # Selectors (relative to the item_soup)
     user_profile_link_selector_bs = "a.css-e5vv35"
     user_name_selector_within_link_bs = "h2.css-o7x4kv"
     followed_back_status_selector_bs = "div.css-b8hsdn"
+    # New selector for last activity date based on user's HTML snippet
+    # Assuming the <p class="ActivityItem__Meta"> is within the <li> item parsed
+    # If the class names are dynamic (like data-v-...), we might need a more general selector
+    # For now, targeting the specific class provided.
+    # A more robust selector might be needed if `ActivityItem__Date` is too generic or data-v attributes change.
+    # Let's assume the item_html_content is the content of `li.css-1qsnhpb`
+    # and the date span is a descendant.
+    last_activity_date_selector_bs = "span.ActivityItem__Date"
+    # If ActivityItem__Meta is a more stable parent: "p.ActivityItem__Meta span.ActivityItem__Date"
 
     try:
         profile_link_element = item_soup.select_one(user_profile_link_selector_bs)
@@ -56,16 +71,41 @@ def _parse_user_item_bs(item_html_content):
         if followed_back_element and "フォローされています" in followed_back_element.get_text(strip=True):
             is_followed_back = True
 
+        # Extract last activity date
+        date_span_element = item_soup.select_one(last_activity_date_selector_bs)
+        if date_span_element:
+            date_str_raw = date_span_element.get_text(strip=True) # e.g., "2025.07.06(日)"
+            # Extract the date part "YYYY.MM.DD"
+            date_str_match = date_str_raw.split('(')[0] # Gets "2025.07.06"
+            if date_str_match:
+                try:
+                    dt_object = datetime.strptime(date_str_match, "%Y.%m.%d")
+                    last_activity_date_on_list = dt_object.date()
+                except ValueError:
+                    logger.warning(f"Failed to parse date string '{date_str_match}' from item. Raw: '{date_str_raw}'")
+                    # Fallback for "MM.DD" format if year is missing (assuming current year)
+                    try:
+                        if len(date_str_match.split('.')) == 2: # Looks like "MM.DD"
+                             # This requires knowing the current year, which might be tricky if this is purely static HTML parsing
+                             # For now, we'll stick to YYYY.MM.DD or fail.
+                             # If YAMAP sometimes shows "MM.DD (曜日)" for recent posts within current year,
+                             # this part would need enhancement or rely on another date source from the page if available.
+                             pass # Not implementing MM.DD parsing here without more context on how YAMAP displays it.
+                    except ValueError:
+                         logger.warning(f"Further fallback parsing for '{date_str_match}' also failed.")
+
+
     except Exception as e_bs_parse:
-        # Log error if parsing a specific item fails, but don't let it stop all processing
         logger.error(f"BS parsing error for item: {e_bs_parse}. HTML snippet: {item_html_content[:200]}", exc_info=True)
 
     return {
         'url': profile_url,
         'name': user_name,
-        'is_followed_back': is_followed_back
+        'is_followed_back': is_followed_back,
+        'last_activity_date_on_list': last_activity_date_on_list # New field added
     }
 
+# ... (rest of user_profile_utils.py, including get_my_following_users_profiles) ...
 
 def get_latest_activity_url(driver, user_profile_url):
     """


### PR DESCRIPTION
- Enhanced `_parse_user_item_bs` in `user_profile_utils.py` to extract the last activity date displayed for each user on the 'following' list page.
- `get_my_following_users_profiles` now returns this date.
- Modified `unfollow_inactive_not_following_back_users` in `yamap_auto_domo.py` to use this date, removing the need to call `get_last_activity_date` (which visited individual profiles).
- This significantly speeds up the process and reduces potential errors from loading multiple profile pages.