### PR TITLE
feat: 非アクティブユーザーのアンフォロー処理を並列化および設定調整

### DIFF
--- a/yamap_auto/config.yaml
+++ b/yamap_auto/config.yaml
@@ -58,7 +58,7 @@ follow_back_settings:
   # フォローバック機能を並列処理する場合の最大ワーカー（スレッド）数。
   # enable_parallel_follow_back が true の場合に参照されます。
 
-  delay_per_worker_action_sec: 2.5 # (追加)
+  delay_per_worker_action_sec: 1.5 # (変更) 2.5秒から短縮
   # 並列フォローバック時、各ワーカースレッドがフォローアクションを実行した後の個別の遅延時間 (秒単位)。
   # 逐次処理の場合は action_delays.after_follow_action_sec が使用されます。
 
@@ -153,7 +153,7 @@ search_and_follow_settings:
   # 値を大きくしすぎると、リソース競合やYAMAPサーバーへの過度な負荷により、かえって性能が低下したり、
   # アカウントが一時的に制限されるリスクが高まる可能性があります。
 
-  delay_per_worker_user_processing_sec: 3.5 # (追加)
+  delay_per_worker_user_processing_sec: 2.0 # (変更) 3.5秒から短縮
   # 並列検索＆フォロー時、各ワーカースレッドが1ユーザーの一連の処理（プロフ確認、フォロー、DOMOなど）を完了した後に挿入される個別の遅延時間 (秒単位)。
   # 複数のワーカースレッドが同時にYAMAPへリクエストを送信するため、各アクション後に適切な遅延を入れることで、
   # サーバーへの瞬間的な負荷を軽減し、安定した動作を目指します。
@@ -204,6 +204,12 @@ unfollow_inactive_users_settings:
   delay_after_unfollow_action_sec: 3.0
   # アンフォロー操作を実行した後の待機時間 (秒単位)。UIの反映待ちや負荷軽減のため。
 
+  parallel_profile_page_workers: 24 # (追加) 非アクティブユーザーの最終活動日を取得する際の並列ワーカー数
+
+  enable_parallel_unfollow_action: true # (追加) アンフォローアクション自体の並列実行を有効にするか
+  max_workers_unfollow_action: 24     # (追加) アンフォローアクションの最大ワーカー数
+  delay_per_worker_unfollow_sec: 2.0  # (追加) 各アンフォローワーカースレッドのアクション後の遅延
+
 
 # === 並列処理設定 ===
 # スクリプト内の一部の処理（現在はタイムラインDOMO）を並列実行するための設定です。
@@ -225,7 +231,7 @@ parallel_processing_settings:
   #       これにより、各ワーカーが個別にログイン処理を行う必要がなくなります。
   # false: Cookie共有を行いません (各ワーカーが独立して動作しようとしますが、ログインが必要な操作は失敗する可能性があります)。
 
-  delay_between_thread_tasks_sec: 1.0
+  delay_between_thread_tasks_sec: 0.5 # (変更) 1.0秒から短縮
   # 各並列タスク（例: 個別のDOMO処理）を開始する前に挿入される基本的な遅延時間 (秒単位)。
   # これに加えて、スクリプト内でタスクごとに僅かな追加遅延が加えられることがあります。
   # 同時アクセスを緩和し、サーバー負荷を軽減することを目的としています。

--- a/yamap_auto/yamap_auto_domo.py
+++ b/yamap_auto/yamap_auto_domo.py
@@ -364,18 +364,11 @@ def _fetch_user_last_activity_task(user_profile_url, shared_cookies_for_task, cu
     logger.info(f"{log_prefix_task}Fetching last activity date for {user_profile_url}")
 
     try:
-        # Create a new driver instance for this task to ensure thread safety for browser operations
-        # It's crucial that create_driver_with_cookies correctly initializes and applies cookies
-        # for a valid session.
-        # The current_user_id_for_login_check helps verify the login based on expected mypage elements.
-        # Removed for_task=True as it's not a valid argument for create_driver_with_cookies
         task_driver = create_driver_with_cookies(shared_cookies_for_task, current_user_id_for_login_check)
         if not task_driver:
             logger.error(f"{log_prefix_task}Failed to create WebDriver or verify login for task. Cannot fetch activity date.")
             return {'url': user_profile_url, 'last_activity_date': None, 'error': 'WebDriver/Login failure in task'}
 
-        # Now use this task_driver to call get_last_activity_date
-        # get_last_activity_date itself handles navigation to user_profile_url
         last_activity = get_last_activity_date(task_driver, user_profile_url)
 
         if last_activity:
@@ -396,6 +389,57 @@ def _fetch_user_last_activity_task(user_profile_url, shared_cookies_for_task, cu
             except Exception as e_quit:
                 logger.error(f"{log_prefix_task}Error quitting task WebDriver: {e_quit}", exc_info=True)
 
+# --- Worker Task for unfollowing a user ---
+def _unfollow_user_task(user_profile_url_to_unfollow, user_name_for_log, shared_cookies_for_task, current_user_id_for_login_check, unfollow_settings_for_task):
+    """
+    Worker task to unfollow a single user.
+    Creates its own WebDriver instance.
+    """
+    task_driver = None
+    user_id_log = user_profile_url_to_unfollow.split('/')[-1].split('?')[0]
+    log_prefix_task = f"[UnfollowTask][UID:{user_id_log}] "
+    logger.info(f"{log_prefix_task}Attempting to unfollow user: {user_name_for_log} ({user_profile_url_to_unfollow})")
+    unfollowed_successfully = False
+
+    try:
+        task_driver = create_driver_with_cookies(shared_cookies_for_task, current_user_id_for_login_check)
+        if not task_driver:
+            logger.error(f"{log_prefix_task}Failed to create WebDriver or verify login for unfollow task.")
+            return {'url': user_profile_url_to_unfollow, 'unfollowed': False, 'error': 'WebDriver/Login failure in task'}
+
+        # Navigate to the user's profile page (unfollow_user from follow_utils might expect to be on the page)
+        # However, `follow_utils.unfollow_user` itself handles navigation. So, direct call is fine.
+
+        delay_before_action = unfollow_settings_for_task.get("delay_before_unfollow_action_sec", 2.0)
+        logger.debug(f"{log_prefix_task}Waiting {delay_before_action}s before unfollow action.")
+        time.sleep(delay_before_action)
+
+        if unfollow_user(task_driver, user_profile_url_to_unfollow): # This is from follow_utils
+            logger.info(f"{log_prefix_task}Successfully unfollowed user: {user_name_for_log}")
+            unfollowed_successfully = True
+        else:
+            logger.warning(f"{log_prefix_task}Failed to unfollow user: {user_name_for_log}")
+            # Optional: Add a small delay on failure if not handled by unfollow_user
+            time.sleep(unfollow_settings_for_task.get("delay_after_action_error_sec", 1.0))
+
+
+        delay_after_action = unfollow_settings_for_task.get("delay_per_worker_unfollow_sec", 2.0)
+        logger.debug(f"{log_prefix_task}Waiting {delay_after_action}s after unfollow action.")
+        time.sleep(delay_after_action)
+
+        return {'url': user_profile_url_to_unfollow, 'unfollowed': unfollowed_successfully, 'error': None}
+
+    except Exception as e_task:
+        logger.error(f"{log_prefix_task}Exception during unfollow task for {user_name_for_log}: {e_task}", exc_info=True)
+        return {'url': user_profile_url_to_unfollow, 'unfollowed': False, 'error': str(e_task)}
+    finally:
+        if task_driver:
+            try:
+                task_driver.quit()
+                logger.debug(f"{log_prefix_task}Unfollow Task WebDriver quit successfully.")
+            except Exception as e_quit:
+                logger.error(f"{log_prefix_task}Error quitting Unfollow Task WebDriver: {e_quit}", exc_info=True)
+
 
 def unfollow_inactive_not_following_back_users(driver, my_user_id, shared_cookies=None):
     """
@@ -403,28 +447,27 @@ def unfollow_inactive_not_following_back_users(driver, my_user_id, shared_cookie
     条件：
     1. 自分をフォローバックしていない。
     2. 最終活動記録が指定日数以上前である (個別プロフィールページから並列取得)。
+    3. アンフォローアクション自体も設定に応じて並列実行可能。
     """
-    logger.info("非アクティブかつフォローバックしていないユーザーのアンフォロー処理を開始します (個別ページ確認・並列処理)。")
-    settings = UNFOLLOW_INACTIVE_SETTINGS
+    logger.info("非アクティブかつフォローバックしていないユーザーのアンフォロー処理を開始します。")
+    settings = UNFOLLOW_INACTIVE_SETTINGS # This should be loaded from main_config at the start of the script
     if not settings.get("enable_unfollow_inactive", False):
         logger.info("設定で無効化されているため、アンフォロー処理をスキップします。")
         return 0
 
     inactive_threshold_days = settings.get("inactive_threshold_days", 90)
-    max_to_unfollow = settings.get("max_users_to_unfollow_per_run", 5)
-    max_pages_to_check_following = settings.get("max_pages_for_my_following_list", 10)
+    max_to_unfollow_total = settings.get("max_users_to_unfollow_per_run", 5)
+    max_pages_to_check_following = settings.get("max_pages_for_my_following_list", 10) # This might need its own config
 
-    # Parallel processing settings for fetching activity dates
-    # Read from UNFOLLOW_INACTIVE_SETTINGS first, then fallback to PARALLEL_PROCESSING_SETTINGS or a hardcoded default
-    activity_date_workers = settings.get("parallel_profile_page_workers",
-                                         main_config.get("parallel_processing_settings", {}).get("activity_date_fetch_workers",
-                                                                                                main_config.get("parallel_processing_settings", {}).get("max_workers_generic", 3)))
+    activity_date_workers = settings.get("parallel_profile_page_workers", 3) # Default to 3 if not set
 
-    unfollowed_count = 0
+    # Settings for parallel unfollow actions
+    enable_parallel_unfollow_action = settings.get("enable_parallel_unfollow_action", False)
+    unfollow_action_workers = settings.get("max_workers_unfollow_action", 3) # Default to 3
+
+    unfollowed_this_run_count = 0
 
     logger.info(f"自分がフォローしているユーザーのリストとフォローバック状況を取得します (最大 {max_pages_to_check_following} ページ)。")
-    # get_my_following_users_profiles returns: [{'url': str, 'name': str, 'is_followed_back': bool}]
-    # 'last_activity_date_on_list' was removed from _parse_user_item_bs as per new strategy
     my_following_user_details = get_my_following_users_profiles(driver, my_user_id, max_pages_to_check=max_pages_to_check_following)
 
     if not my_following_user_details:
@@ -432,99 +475,119 @@ def unfollow_inactive_not_following_back_users(driver, my_user_id, shared_cookie
         return 0
     logger.info(f"{len(my_following_user_details)} 件のフォロー中ユーザー情報を取得しました。")
 
-    non_followers_back = []
-    for user_detail in my_following_user_details:
-        if not user_detail['is_followed_back']:
-            non_followers_back.append(user_detail) # Store the whole user_detail dict
-        else:
-            user_id_log_filter = user_detail['url'].split('/')[-1].split('?')[0]
-            logger.info(f"ユーザー {user_detail['name']} ({user_id_log_filter}) はフォローバックしています。アンフォロー対象外 (初期フィルタ)。")
+    non_followers_back = [
+        ud for ud in my_following_user_details if not ud['is_followed_back']
+    ]
+    logger.info(f"{len(my_following_user_details) - len(non_followers_back)} 件は相互フォローのため対象外。")
+
 
     if not non_followers_back:
         logger.info("フォローバックしていないユーザーが見つかりませんでした。処理を終了します。")
         return 0
 
     logger.info(f"{len(non_followers_back)} 件のフォローバックしていないユーザーについて、最終活動日を並列で確認します (最大ワーカー数: {activity_date_workers})。")
-
-    users_with_activity_dates = {} # Store {url: date_obj or None}
-    futures = []
-    # Ensure shared_cookies are available for tasks, even if main driver is used for this initial part
-    if not shared_cookies:
+    users_with_activity_dates = {}
+    activity_futures = []
+    if not shared_cookies: # Ensure shared_cookies for tasks
         logger.warning("共有Cookieが利用できません。並列タスクでのログイン状態が不安定になる可能性があります。")
-        # Optionally, try to get them now if driver is the main one and logged in
-        # shared_cookies = get_shared_cookies(driver) # This might be risky if driver state changed
 
-    with ThreadPoolExecutor(max_workers=activity_date_workers) as executor:
-        for user_data_for_task in non_followers_back:
-            # Pass my_user_id for the login check inside create_driver_with_cookies
-            future = executor.submit(_fetch_user_last_activity_task, user_data_for_task['url'], shared_cookies, my_user_id)
-            futures.append(future)
+    with ThreadPoolExecutor(max_workers=activity_date_workers, thread_name_prefix='ActivityDateFetch') as executor:
+        for user_data in non_followers_back:
+            future = executor.submit(_fetch_user_last_activity_task, user_data['url'], shared_cookies, my_user_id)
+            activity_futures.append(future)
 
-        for future in as_completed(futures):
+        for future in as_completed(activity_futures):
             try:
                 result = future.result()
                 if result and result.get('url'):
                     users_with_activity_dates[result['url']] = result.get('last_activity_date')
                     if result.get('error'):
                          logger.warning(f"ユーザー ({result['url'].split('/')[-1]}) の最終活動日取得タスクでエラー: {result['error']}")
-                else:
-                    logger.error(f"並列タスクから無効な結果が返されました: {result}")
             except Exception as e_future:
                 logger.error(f"最終活動日取得の並列タスク実行中に例外: {e_future}", exc_info=True)
 
     logger.info(f"{len(users_with_activity_dates)}/{len(non_followers_back)} 件のフォローバックしていないユーザーの最終活動日情報を収集完了。")
 
-    processed_for_unfollow_count = 0
-    # Iterate through the original non_followers_back list to maintain user_data structure (name, etc.)
-    for user_data_to_check in non_followers_back:
-        if unfollowed_count >= max_to_unfollow:
-            logger.info(f"1回の実行でのアンフォロー上限 ({max_to_unfollow}人) に達しました。")
-            break
-
-        user_profile_url = user_data_to_check['url']
-        user_name_for_log = user_data_to_check['name']
-        user_id_log = user_profile_url.split('/')[-1].split('?')[0]
-
-        last_activity_date = users_with_activity_dates.get(user_profile_url) # Get fetched date
-
-        processed_for_unfollow_count +=1
-        logger.info(f"--- アンフォロー判定 ({processed_for_unfollow_count}/{len(non_followers_back)}): {user_name_for_log} ({user_id_log}) ---")
-
-        if last_activity_date is None:
-            logger.warning(f"    ユーザー {user_name_for_log} ({user_id_log}) の最終活動日を取得できませんでした (並列処理後)。スキップ。")
-            # Add delay if defined in settings for skipped users
-            time.sleep(settings.get("delay_between_unfollow_decisions_sec", 1.0))
-            continue
-
-        days_since_last_activity = (datetime.date.today() - last_activity_date).days
-        logger.info(f"    最終活動日: {last_activity_date} ({days_since_last_activity}日前)。 (閾値: {inactive_threshold_days}日)")
-
-        if days_since_last_activity >= inactive_threshold_days:
-            logger.info(f"    ユーザー {user_name_for_log} ({user_id_log}) は非アクティブと判断。アンフォローを試みます。")
-            delay_before_unfollow = settings.get("delay_before_unfollow_action_sec", 2.0)
-            logger.debug(f"    アンフォロー実行前に {delay_before_unfollow} 秒待機します。")
-            time.sleep(delay_before_unfollow)
-
-            # unfollow_user is called with the main driver instance.
-            # If unfollow_user itself needs to navigate, this is fine.
-            # If unfollow_user was also to be parallelized, it would need its own driver.
-            if unfollow_user(driver, user_profile_url):
-                logger.info(f"    ユーザー {user_name_for_log} ({user_id_log}) のアンフォローに成功しました。")
-                unfollowed_count += 1
+    # Filter for inactive users
+    inactive_unfollowed_candidates = []
+    for user_data in non_followers_back:
+        user_profile_url = user_data['url']
+        last_activity_date = users_with_activity_dates.get(user_profile_url)
+        if last_activity_date:
+            days_since_last_activity = (datetime.date.today() - last_activity_date).days
+            if days_since_last_activity >= inactive_threshold_days:
+                inactive_unfollowed_candidates.append(user_data) # user_data includes name and url
             else:
-                logger.warning(f"    ユーザー {user_name_for_log} ({user_id_log}) のアンフォローに失敗しました。")
-                time.sleep(settings.get("delay_after_action_error_sec", 3.0))
+                 logger.info(f"ユーザー {user_data['name']} ({user_profile_url.split('/')[-1]}) は活動閾値内 ({days_since_last_activity}日前)。アンフォロー対象外。")
         else:
-            logger.info(f"    ユーザー {user_name_for_log} ({user_id_log}) は活動閾値内に活動あり。アンフォロー対象外。")
+            logger.warning(f"ユーザー {user_data['name']} ({user_profile_url.split('/')[-1]}) の最終活動日不明。アンフォロー対象外。")
 
-        # Delay before processing the next user for unfollow decision
-        if unfollowed_count < max_to_unfollow and processed_for_unfollow_count < len(non_followers_back):
-            # Ensure this delay key exists or use a default
-            time.sleep(settings.get("delay_between_unfollow_decisions_sec", 2.0))
-        logger.info(f"--- アンフォロー判定終了: {user_name_for_log} ({user_id_log}) ---")
+    if not inactive_unfollowed_candidates:
+        logger.info("非アクティブと判定されたフォローバックしていないユーザーが見つかりませんでした。")
+        return 0
 
-    logger.info(f"非アクティブユーザーのアンフォロー処理完了。合計 {unfollowed_count} 人をアンフォローしました。")
-    return unfollowed_count
+    logger.info(f"{len(inactive_unfollowed_candidates)} 件の非アクティブかつ未フォローバックユーザーをアンフォロー対象候補とします。")
+
+    # Perform unfollow actions (sequentially or in parallel)
+    users_to_actually_unfollow = inactive_unfollowed_candidates[:max_to_unfollow_total]
+    logger.info(f"最大アンフォロー数 ({max_to_unfollow_total}) に基づき、{len(users_to_actually_unfollow)} 件を処理します。")
+
+    if enable_parallel_unfollow_action:
+        logger.info(f"アンフォローアクションを並列で実行します (最大ワーカー数: {unfollow_action_workers})。")
+        unfollow_futures = []
+        with ThreadPoolExecutor(max_workers=unfollow_action_workers, thread_name_prefix='UnfollowAction') as executor:
+            for user_to_unfollow_data in users_to_actually_unfollow:
+                if unfollowed_this_run_count >= max_to_unfollow_total: break # Redundant check, but safe
+
+                # Pass the whole settings dict for the task to pick necessary delays
+                future = executor.submit(_unfollow_user_task,
+                                         user_to_unfollow_data['url'],
+                                         user_to_unfollow_data['name'],
+                                         shared_cookies,
+                                         my_user_id,
+                                         settings) # Pass the full settings dict
+                unfollow_futures.append(future)
+
+            for future in as_completed(unfollow_futures):
+                try:
+                    result = future.result()
+                    if result and result.get('unfollowed'):
+                        unfollowed_this_run_count += 1
+                    if result and result.get('error'):
+                        logger.error(f"並列アンフォロータスクでエラー (URL: {result.get('url', 'N/A')}): {result['error']}")
+                except Exception as e_future_unfollow:
+                    logger.error(f"並列アンフォロータスクの結果取得中に例外: {e_future_unfollow}", exc_info=True)
+    else:
+        logger.info("アンフォローアクションを逐次実行します。")
+        for user_data_to_unfollow_seq in users_to_actually_unfollow:
+            if unfollowed_this_run_count >= max_to_unfollow_total:
+                logger.info(f"アンフォロー上限 ({max_to_unfollow_total}人) に達しました (逐次処理中)。")
+                break
+
+            user_profile_url_seq = user_data_to_unfollow_seq['url']
+            user_name_seq = user_data_to_unfollow_seq['name']
+            user_id_log_seq = user_profile_url_seq.split('/')[-1].split('?')[0]
+
+            logger.info(f"--- 逐次アンフォロー試行: {user_name_seq} ({user_id_log_seq}) ---")
+            delay_before_unfollow_seq = settings.get("delay_before_unfollow_action_sec", 2.0)
+            logger.debug(f"    アンフォロー実行前に {delay_before_unfollow_seq} 秒待機します。")
+            time.sleep(delay_before_unfollow_seq)
+
+            # Use the main driver for sequential unfollow
+            if unfollow_user(driver, user_profile_url_seq):
+                logger.info(f"    ユーザー {user_name_seq} ({user_id_log_seq}) のアンフォローに成功しました。")
+                unfollowed_this_run_count += 1
+            else:
+                logger.warning(f"    ユーザー {user_name_seq} ({user_id_log_seq}) のアンフォローに失敗しました。")
+                time.sleep(settings.get("delay_after_action_error_sec", 3.0)) # Delay on error
+
+            if unfollowed_this_run_count < max_to_unfollow_total:
+                 time.sleep(settings.get("delay_per_worker_unfollow_sec", 2.0)) # Use this as delay between sequential actions too
+            logger.info(f"--- 逐次アンフォロー試行完了: {user_name_seq} ({user_id_log_seq}) ---")
+
+
+    logger.info(f"非アクティブユーザーのアンフォロー処理完了。この実行で合計 {unfollowed_this_run_count} 人をアンフォローしました。")
+    return unfollowed_this_run_count
 
 
 def main():


### PR DESCRIPTION
- `unfollow_inactive_not_following_back_users` 関数内のアンフォロー実行処理を並列化しました。
- 上記並列化のため、ワーカースレッド用関数 `_unfollow_user_task` を新設しました。
- `config.yaml` の `unfollow_inactive_users_settings` に以下の設定項目を追加しました:
    - `enable_parallel_unfollow_action`
    - `max_workers_unfollow_action` (初期値24)
    - `delay_per_worker_unfollow_sec`
- `config.yaml` の `unfollow_inactive_users_settings` に `parallel_profile_page_workers` (初期値24) を追加しました。
- 各機能の並列処理におけるワーカースレッドごとの遅延時間を短縮しました。