### PR TITLE
feat: 過去DOMOユーザーへのDOMO返し機能の骨組み追加とエラー修正

### DIFF
--- a/TASK_MANAGEMENT.md
+++ b/TASK_MANAGEMENT.md
@@ -1,10 +1,18 @@
 # タスク管理
 
-最終更新日時: 2025/07/09
+最終更新日時: 2025/07/10
 
 ---
 
 ## 🛠 仕掛中タスク
+*   [ ] **エラー修正:** 活動記録ページの読み込みタイムアウトエラー対応 (コミット: `[IN_PROGRESS]`)
+    *   `my_post_interaction_utils.py` の `get_domo_users_from_activity` 関数内の待機時間を25秒から35秒に延長。
+*   [ ] **新機能:** 過去の記事にDOMOくれたユーザーに対して最新記事にDOMOを返す (コミット: `[IN_PROGRESS]`)
+    *   [x] `config.yaml` に機能設定項目 `new_feature_domo_back_to_past_domo_users` を追加。
+    *   [x] `my_post_interaction_utils.py` に設定読み込み関数 `_get_domo_back_settings` を追加。
+    *   [x] `my_post_interaction_utils.py` にメイン処理関数 `domo_back_to_past_domo_users` の雛形を追加。
+    *   [x] `yamap_auto_domo.py` の `execute_main_tasks` 及びサマリー出力に上記新機能の呼び出しと結果表示を統合。
+    *   [ ] `my_post_interaction_utils.py` の `domo_back_to_past_domo_users` 関数の詳細ロジックを実装。
 *   [ ] **修正:** `user_profile_utils.py` のリストアイテム取得時のWebDriverWaitタイムアウトを30秒に延長 (コミット: `[NEEDS_ACTUAL_COMMIT_HASH]`)
     *   動的読み込みされるリストアイテムの表示待ち時間延長のため。
 *   [ ] **修正:** `user_profile_utils.py` のフォロー/フォロワーリスト関連CSSセレクタを詳細化 (コミット: `[PREVIOUS_COMMIT_HASH]`)

--- a/yamap_auto/config.yaml
+++ b/yamap_auto/config.yaml
@@ -178,6 +178,36 @@ new_feature_my_post_interaction:
   #   既存の `follow_back_settings` の値を参照・準拠するよう実装されています（ただし現実装では簡略化）。
   # - DOMOユーザーの最新活動記録へのDOMOは、1件のみ行われます。
 
+# === 新機能: 過去記事DOMOユーザーへの最新記事DOMO返し設定 ===
+new_feature_domo_back_to_past_domo_users:
+  enable_domo_back_to_past_users: false
+  # true: この機能を有効にします。
+  # false: この機能を無効にします。
+
+  max_days_to_check_past_activities: 30
+  # DOMO返しのためにチェックする自分の過去記事の期間（日数）。
+
+  max_past_activities_to_process: 5
+  # DOMO返しのために処理する自分の過去記事の最大数。
+  # 例: 期間内に10件の記事があっても、この値が5なら新しい方から5件のみ処理。
+
+  max_users_to_domo_back_per_activity: 10
+  # 1つの自分の過去記事あたり、DOMO返しを行うユーザーの最大数。
+
+  max_total_domo_back_users_per_run: 20
+  # 1回のスクリプト実行でDOMO返しを行うユーザーの総最大数。
+
+  enable_domo_only_if_not_following_me: false
+  # true: 自分をまだフォローしていないユーザーに限定してDOMO返しを行います。
+  # false: フォロー状況に関わらずDOMO返しを行います。
+
+  enable_domo_only_if_i_am_not_following: true
+  # true: 自分がまだフォローしていないユーザーに限定してDOMO返しを行います。
+  # false: 自分が既にフォローしているユーザーにもDOMO返しを行います。
+
+  delay_between_domo_back_action_sec: 5.0
+  # 各DOMO返しアクション間の遅延時間 (秒単位)。
+
 # === 新機能: 非アクティブかつ非相互フォローユーザーのアンフォロー設定 ===
 unfollow_inactive_users_settings:
   enable_unfollow_inactive: true

--- a/yamap_auto/my_post_interaction_utils.py
+++ b/yamap_auto/my_post_interaction_utils.py
@@ -35,6 +35,10 @@ def _get_follow_back_settings_for_interaction():
     config = _get_config_cached()
     return config.get("follow_back_settings", {})
 
+def _get_domo_back_settings():
+    config = _get_config_cached()
+    return config.get("new_feature_domo_back_to_past_domo_users", {})
+
 
 def get_my_activities_within_period(driver, user_profile_url, days_to_check):
     """
@@ -196,7 +200,7 @@ def get_domo_users_from_activity(driver, activity_url):
 
     try:
         logger.info(f"活動記録ページ ({activity_id_for_log}) の主要コンテナ ({activity_page_container_selector}) の表示を待ちます...")
-        WebDriverWait(driver, 25).until(
+        WebDriverWait(driver, 35).until( # 待機時間を25秒から35秒に延長
             EC.presence_of_element_located((By.CSS_SELECTOR, activity_page_container_selector))
         )
         logger.info(f"活動記録ページ ({activity_id_for_log}) の主要コンテナの表示を確認。")
@@ -425,3 +429,119 @@ def interact_with_domo_users_on_my_posts(driver, current_user_id, shared_cookies
     logger.info(f"  合計フォローバック数: {total_followed_back_count}")
     logger.info(f"  合計DOMO成功数（DOMOユーザーへ）: {total_domoed_to_users_count}")
     return total_followed_back_count, total_domoed_to_users_count
+
+
+def domo_back_to_past_domo_users(driver, current_user_id, shared_cookies):
+    """
+    自分の過去の活動記録にDOMOしてくれたユーザーに対して、そのユーザーの最新の活動記録にDOMOを返す機能。
+    """
+    db_settings = _get_domo_back_settings()
+    if not db_settings.get("enable_domo_back_to_past_users", False):
+        logger.info("過去記事DOMOユーザーへのDOMO返し機能は設定で無効です。")
+        return 0
+
+    logger.info(">>> 過去記事DOMOユーザーへのDOMO返し機能を開始します...")
+    start_time = time.time()
+
+    days_to_check_past = db_settings.get("max_days_to_check_past_activities", 30)
+    max_past_activities = db_settings.get("max_past_activities_to_process", 5)
+    max_users_per_activity = db_settings.get("max_users_to_domo_back_per_activity", 10)
+    max_total_users_overall = db_settings.get("max_total_domo_back_users_per_run", 20)
+    domo_if_not_following_me = db_settings.get("enable_domo_only_if_not_following_me", False)
+    domo_if_i_am_not_following = db_settings.get("enable_domo_only_if_i_am_not_following", True)
+    delay_action_sec = db_settings.get("delay_between_domo_back_action_sec", 5.0)
+
+    my_profile_url = f"{BASE_URL}/users/{current_user_id}"
+    total_domoed_back_count = 0
+    processed_users_for_domo_back_this_session = set() # (user_profile_url) を記録
+
+    # 1. 自分の過去の活動記録を取得
+    # get_my_activities_within_period を使用
+    logger.info(f"過去 {days_to_check_past} 日間の自分の活動記録を取得します (最大 {max_past_activities} 件処理)。")
+    # my_past_activities_urls = get_my_activities_within_period(driver, my_profile_url, days_to_check_past)
+    # if not my_past_activities_urls:
+    #     logger.info("DOMO返し対象の過去の活動記録が見つかりませんでした。")
+    #     return 0
+    #
+    # # 新しいものから処理するため、必要なら逆順にする (get_my_activities_within_periodは新しい順のはず)
+    # activities_to_process = my_past_activities_urls[:max_past_activities]
+    # logger.info(f"{len(activities_to_process)} 件の過去活動記録を処理対象とします。")
+
+    # for past_activity_url in activities_to_process:
+    #     if total_domoed_back_count >= max_total_users_overall:
+    #         logger.info(f"今回の実行でのDOMO返し総数が上限 ({max_total_users_overall}) に達しました。")
+    #         break
+    #
+    #     activity_id_log = past_activity_url.split('/')[-1].split('?')[0]
+    #     logger.info(f"--- 過去活動記録 ({activity_id_log}) のDOMOユーザーを確認 ---")
+    #
+    #     # 2. 各過去記事のDOMOユーザーリストを取得
+    #     # get_domo_users_from_activity を使用
+    #     # past_domo_users = get_domo_users_from_activity(driver, past_activity_url)
+    #     # if not past_domo_users:
+    #     #     logger.info(f"活動記録 ({activity_id_log}) にDOMOユーザーがいませんでした。")
+    #     #     continue
+    #
+    #     domoed_for_this_activity_count = 0
+    #     # for domo_user_info in past_domo_users:
+    #     #     if total_domoed_back_count >= max_total_users_overall: break
+    #     #     if domoed_for_this_activity_count >= max_users_per_activity:
+    #     #         logger.info(f"この活動記録 ({activity_id_log}) でのDOMO返し数が上限 ({max_users_per_activity}) に達しました。")
+    #     #         break
+    #     #
+    #     #     user_profile_url = domo_user_info["profile_url"]
+    #     #     user_name = domo_user_info["name"]
+    #     #     user_id_short = user_profile_url.split('/')[-1]
+    #     #
+    #     #     if user_id_short == str(current_user_id): # 自分自身はスキップ
+    #     #         continue
+    #     #     if user_profile_url in processed_users_for_domo_back_this_session:
+    #     #         logger.debug(f"ユーザー ({user_name}) は既にDOMO返し処理済みのためスキップ。")
+    #     #         continue
+    #     #
+    #     #     # 3. 条件確認
+    #     #     #   - enable_domo_only_if_not_following_me: 相手が自分をフォローしていないか (is_user_following_me)
+    #     #     #   - enable_domo_only_if_i_am_not_following: 自分が相手をフォローしていないか (find_follow_button_on_profile_page)
+    #     #
+    #     #     # (条件確認ロジック ... driver を使ってプロフィールページにアクセスなどが必要)
+    #     #     should_domo_back = True # 仮
+    #     #
+    #     #     # if domo_if_not_following_me:
+    #     #     #     # is_user_following_me(driver, my_profile_url, user_profile_url, shared_cookies) ...
+    #     #     #     pass
+    #     #     # if domo_if_i_am_not_following:
+    #     #     #     # driver.get(user_profile_url) ... find_follow_button_on_profile_page(driver)
+    #     #     #     pass
+    #     #
+    #     #     if not should_domo_back:
+    #     #         processed_users_for_domo_back_this_session.add(user_profile_url) # 条件外でも処理済み扱い
+    #     #         continue
+    #     #
+    #     #     # 4. ユーザーの最新活動記録にDOMO
+    #     #     # get_latest_activity_url を使用
+    #     #     # domo_activity を使用
+    #     #     logger.info(f"ユーザー ({user_name}, {user_id_short}) の最新活動記録へDOMO返しを試みます。")
+    #     #     # latest_user_activity_url = get_latest_activity_url(driver, user_profile_url)
+    #     #     # if latest_user_activity_url:
+    #     #     #     if domo_activity(driver, latest_user_activity_url):
+    #     #     #         logger.info(f"  -> 成功: {user_name} の最新活動 ({latest_user_activity_url.split('/')[-1]}) へのDOMO返し")
+    #     #     #         total_domoed_back_count += 1
+    #     #     #         domoed_for_this_activity_count += 1
+    #     #     #     else:
+    #     #     #         logger.info(f"  -> スキップ/失敗: {user_name} の最新活動へのDOMO返し")
+    #     #     # else:
+    #     #     #     logger.info(f"ユーザー ({user_name}) の最新活動記録が見つかりませんでした。DOMO返しスキップ。")
+    #     #
+    #     #     processed_users_for_domo_back_this_session.add(user_profile_url)
+    #     #     if total_domoed_back_count < max_total_users_overall and domoed_for_this_activity_count < max_users_per_activity :
+    #     #         logger.debug(f"DOMO返しアクション後、{delay_action_sec}秒待機します。")
+    #     #         time.sleep(delay_action_sec)
+
+    # 仮実装として0を返す
+    logger.warning("domo_back_to_past_domo_users はまだ完全には実装されていません。")
+    total_domoed_back_count = 0 # 現時点では何もしないので0
+
+    end_time = time.time()
+    logger.info(f"<<< 過去記事DOMOユーザーへのDOMO返し機能完了。処理時間: {end_time - start_time:.2f}秒。")
+    logger.info(f"  合計DOMO返し成功数: {total_domoed_back_count}")
+    return total_domoed_back_count


### PR DESCRIPTION
- 活動記録ページ読み込み時のタイムアウトエラーに対し、待機時間を延長 (25s -> 35s)。
- 新機能「過去の記事にDOMOくれたユーザーに対し、そのユーザーの最新記事にDOMOを返す」の骨組みを実装。
  - `config.yaml` に機能設定項目を追加。
  - `my_post_interaction_utils.py` に処理関数の雛形と設定読み込みロジックを追加。
  - `yamap_auto_domo.py` のメイン処理に機能呼び出しとサマリー出力を統合。
  - 詳細なDOMO返しロジックは未実装。
- `TASK_MANAGEMENT.md` を更新。