### PR TITLE
fix: 活動記録ページ読み込みセレクタを再修正

### DIFF
--- a/TASK_MANAGEMENT.md
+++ b/TASK_MANAGEMENT.md
@@ -8,6 +8,7 @@
 *   [x] **エラー修正:** 活動記録ページの読み込みタイムアウトエラー対応 (コミット: `[IN_PROGRESS]`)
     *   `my_post_interaction_utils.py` の `get_domo_users_from_activity` 関数内の待機時間を35秒に延長。
     *   セレクタを `div[data-testid='activity-detail-view']` から `main.ActivitiesId__Main` に変更。
+    *   さらにセレクタを `main.ActivitiesId__Main` から `div.ActivitiesId` に変更。
 *   [ ] **新機能:** 過去の記事にDOMOくれたユーザーに対して最新記事にDOMOを返す (コミット: `[IN_PROGRESS]`)
     *   [x] `config.yaml` に機能設定項目 `new_feature_domo_back_to_past_domo_users` を追加。
     *   [x] `my_post_interaction_utils.py` に設定読み込み関数 `_get_domo_back_settings` を追加。

--- a/yamap_auto/my_post_interaction_utils.py
+++ b/yamap_auto/my_post_interaction_utils.py
@@ -195,17 +195,18 @@ def get_domo_users_from_activity(driver, activity_url):
 
     driver.get(activity_url)
     # Attempt to wait for a general activity page container
-    activity_page_container_selector = "main.ActivitiesId__Main" # セレクタを変更
-    activity_title_selector = "h1.ActivityDetailTabLayout__Title" # タイトルセレクタもHTMLに合わせて更新
+    activity_page_container_selector = "div.ActivitiesId" # 新しいセレクタ案
+    activity_title_selector = "h1.ActivityDetailTabLayout__Title" # これは div.ActivitiesId の内部にある想定
 
     try:
         logger.info(f"活動記録ページ ({activity_id_for_log}) の主要コンテナ ({activity_page_container_selector}) の表示を待ちます...")
         WebDriverWait(driver, 35).until(
             EC.presence_of_element_located((By.CSS_SELECTOR, activity_page_container_selector))
         )
-        logger.info(f"活動記録ページ ({activity_id_for_log}) の主要コンテナの表示を確認。")
+        logger.info(f"活動記録ページ ({activity_id_for_log}) の主要コンテナ ({activity_page_container_selector}) の表示を確認。")
 
-        # Try to find the specific title, but don't fail if it's not there
+        # 主要コンテナが表示された後、少し待ってからタイトル要素の確認を試みる (念のため)
+        time.sleep(0.5)
         try:
             title_element = driver.find_element(By.CSS_SELECTOR, activity_title_selector)
             if title_element.is_displayed():
@@ -217,11 +218,11 @@ def get_domo_users_from_activity(driver, activity_url):
 
     except TimeoutException:
         logger.error(f"活動記録ページ ({activity_url}) の主要コンテナ ({activity_page_container_selector}) の読み込み確認タイムアウト。")
-        save_screenshot(driver, "ActivityPageContainerLoadFail", activity_id_for_log)
+        save_screenshot(driver, "ActivityPageContainerLoadFail_NewSel", activity_id_for_log) # スクリーンショットファイル名変更
         return domo_users
     except Exception as e_page_load:
         logger.error(f"活動記録ページ ({activity_url}) の読み込み中に予期せぬエラー: {e_page_load}", exc_info=True)
-        save_screenshot(driver, "ActivityPageLoadGenericError", activity_id_for_log)
+        save_screenshot(driver, "ActivityPageLoadGenericError_NewSel", activity_id_for_log) # スクリーンショットファイル名変更
         return domo_users
 
     # DOMOしたユーザー一覧へ遷移するボタンを探す (クラス名とテキスト内容で判断)


### PR DESCRIPTION
- 活動記録ページ読み込みタイムアウトエラーへの対応として、主要コンテナのセレクタを `main.ActivitiesId__Main` から `div.ActivitiesId` に再修正。
- タイムアウト時のスクリーンショットファイル名を変更し、デバッグ情報を拡充。
- 主要コンテナ表示後の微小な待機時間を追加。
- `TASK_MANAGEMENT.md` を更新。