### PR TITLE
Refactor: Remove redundant new_feature_my_post_interaction

### DIFF
--- a/yamap_auto/config.yaml
+++ b/yamap_auto/config.yaml
@@ -160,24 +160,6 @@ search_and_follow_settings:
   # この値が小さすぎると、YAMAPからの応答エラーやアカウント制限のリスクが高まる可能性があります。
   # 逐次処理の場合は `delay_between_user_processing_in_search_sec` がユーザー間の遅延として使用されます。
 
-# === 新機能: 自分の投稿へのDOMOユーザーインタラクション設定 ===
-new_feature_my_post_interaction:
-  enable_my_post_interaction: true
-  # true: この機能を有効にします。
-  # false: この機能を無効にします。
-
-  max_days_to_check_my_posts: 7
-  # 何日前までの自分の活動記録をチェック対象とするか (例: 7 であれば過去7日間の投稿)。
-
-  delay_between_user_interaction_sec: 4.0
-  # DOMOをくれた各ユーザーへのインタラクション（フォローバック試行、最新投稿へのDOMO試行）の間に挿入される遅延時間 (秒単位)。
-  # サーバー負荷軽減と安定動作のため。
-
-  # 注意:
-  # - この機能によるフォローバックの条件（例: フォロワー数レシオなど）は、
-  #   既存の `follow_back_settings` の値を参照・準拠するよう実装されています（ただし現実装では簡略化）。
-  # - DOMOユーザーの最新活動記録へのDOMOは、1件のみ行われます。
-
 # === 新機能: 過去記事DOMOユーザーへの最新記事DOMO返し設定 ===
 new_feature_domo_back_to_past_domo_users:
   enable_domo_back_to_past_users: false

--- a/yamap_auto/my_post_interaction_utils.py
+++ b/yamap_auto/my_post_interaction_utils.py
@@ -29,28 +29,29 @@ from .follow_utils import click_follow_button_and_verify
 logger = logging.getLogger(__name__)
 
 # --- 設定情報の読み込み ---
-_main_config_cache_mpi = None # my_post_interaction 用のキャッシュ変数名に変更
+_main_config_cache = None # Cache variable
 
-def _get_config_cached_mpi(): # 関数名も変更
-    global _main_config_cache_mpi
-    if _main_config_cache_mpi is None:
-        _main_config_cache_mpi = get_main_config()
-    return _main_config_cache_mpi
+def _get_config_cached(): # Generic config cache function
+    global _main_config_cache
+    if _main_config_cache is None:
+        _main_config_cache = get_main_config()
+    return _main_config_cache
 
-def _get_my_post_interaction_settings(): # このモジュール固有の設定
-    config = _get_config_cached_mpi()
-    return config.get("new_feature_my_post_interaction", {})
+# This function is being removed:
+# def _get_my_post_interaction_settings(): # このモジュール固有の設定
+#     config = _get_config_cached()
+#     return config.get("new_feature_my_post_interaction", {})
 
 def _get_domo_back_settings(): # DOMO返し機能の設定
-    config = _get_config_cached_mpi()
+    config = _get_config_cached()
     return config.get("new_feature_domo_back_to_past_domo_users", {})
 
 def _get_search_follow_settings_for_domo_back(): # フォロー条件参照用
-    config = _get_config_cached_mpi()
+    config = _get_config_cached()
     return config.get("search_and_follow_settings", {})
 
-def _get_action_delays_mpi(): # アクション遅延設定
-    config = _get_config_cached_mpi()
+def _get_action_delays_mpi(): # アクション遅延設定 (名前はそのままMPIだが汎用的に使える)
+    config = _get_config_cached()
     return config.get("action_delays", {})
 
 
@@ -378,102 +379,8 @@ def get_domo_users_from_activity(driver, activity_url):
     return domo_users
 
 
-def interact_with_domo_users_on_my_posts(driver, current_user_id, shared_cookies):
-    """
-    自分の指定期間内の投稿にDOMOしたユーザーに対し、フォローバックや最新投稿へのDOMOを行う。
-    """
-    mpi_settings = _get_my_post_interaction_settings()
-    if not mpi_settings.get("enable_my_post_interaction", False):
-        logger.info("自分の投稿へのDOMOユーザーインタラクション機能は無効です。")
-        return 0, 0
-
-    logger.info(">>> 自分の投稿へのDOMOユーザーインタラクション機能を開始します...")
-    days_to_check = mpi_settings.get("max_days_to_check_my_posts", 7)
-    my_profile_url = f"{BASE_URL}/users/{current_user_id}"
-
-    my_activities = get_my_activities_within_period(driver, my_profile_url, days_to_check)
-    if not my_activities:
-        logger.info("対象期間内に処理すべき自分の活動記録が見つかりませんでした。")
-        return 0, 0
-
-    total_followed_back_count = 0
-    total_domoed_to_users_count = 0
-
-    fb_settings_for_interaction = _get_follow_back_settings_for_interaction()
-    action_delays = _get_config_cached().get("action_delays", {})
-    processed_user_interactions_this_session = set()
-
-    for activity_url in my_activities:
-        activity_id_log = activity_url.split('/')[-1].split('?')[0]
-        logger.info(f"--- 活動記録 ({activity_id_log}) のDOMOユーザーへのインタラクションを開始 ---")
-        domo_users = get_domo_users_from_activity(driver, activity_url)
-        if not domo_users:
-            logger.info(f"活動記録 ({activity_id_log}) にDOMOユーザーがいませんでした。")
-            continue
-
-        for domo_user in domo_users:
-            user_name = domo_user["name"]
-            user_profile_url_clean = domo_user["profile_url"]
-            user_id_short = user_profile_url_clean.split('/')[-1]
-
-            if user_id_short == str(current_user_id):
-                logger.debug(f"DOMOユーザー ({user_name}) は自分自身なのでスキップします。")
-                continue
-
-            if (user_profile_url_clean, 'follow_back') not in processed_user_interactions_this_session:
-                logger.info(f"DOMOユーザー ({user_name}, {user_id_short}) のフォロー状態を確認・試行します。")
-                driver.get(user_profile_url_clean)
-                try:
-                    WebDriverWait(driver, 10).until(EC.url_contains(user_id_short))
-                    follow_button_on_profile = find_follow_button_on_profile_page(driver)
-                    if follow_button_on_profile:
-                        logger.info(f"ユーザー ({user_name}) はまだフォローしていません。フォローバックを試みます。")
-                        if click_follow_button_and_verify(driver, follow_button_on_profile, user_name):
-                            total_followed_back_count += 1
-                            logger.info(f"ユーザー ({user_name}) のフォローバックに成功しました。")
-                        else:
-                            logger.warning(f"ユーザー ({user_name}) のフォローバック試行に失敗しました。")
-                        time.sleep(action_delays.get("after_follow_action_sec", 2.0))
-                    else:
-                        logger.info(f"ユーザー ({user_name}) は既にフォロー済みか、フォローボタンが見つかりませんでした。")
-                    processed_user_interactions_this_session.add((user_profile_url_clean, 'follow_back'))
-                except TimeoutException:
-                    logger.error(f"ユーザー ({user_name}) のプロフィールページ ({user_profile_url_clean}) 読み込みタイムアウト。フォローバック処理スキップ。")
-                    save_screenshot(driver, f"FollowBackProfileLoadTimeout_{user_id_short}")
-                except Exception as e_fb:
-                    logger.error(f"ユーザー ({user_name}) のフォローバック処理中にエラー: {e_fb}", exc_info=True)
-                    save_screenshot(driver, f"FollowBackError_{user_id_short}")
-            else:
-                logger.info(f"ユーザー ({user_name}) のフォローバックは既に試行済みです。")
-
-            if mpi_settings.get("enable_domo_to_latest_activity", True):
-                if (user_profile_url_clean, 'domo_latest') not in processed_user_interactions_this_session:
-                    logger.info(f"DOMOユーザー ({user_name}, {user_id_short}) の最新活動記録へのDOMOを試みます。")
-                    latest_activity_url = get_latest_activity_url(driver, user_profile_url_clean)
-                    if latest_activity_url:
-                        latest_activity_id_log = latest_activity_url.split('/')[-1].split('?')[0]
-                        logger.info(f"ユーザー ({user_name}) の最新活動記録URL: {latest_activity_id_log}")
-                        if domo_activity(driver, latest_activity_url):
-                            total_domoed_to_users_count += 1
-                            logger.info(f"ユーザー ({user_name}) の最新活動記録 ({latest_activity_id_log}) へのDOMOに成功しました。")
-                        else:
-                            logger.info(f"ユーザー ({user_name}) の最新活動記録 ({latest_activity_id_log}) へのDOMOはスキップまたは失敗しました。")
-                    else:
-                        logger.info(f"ユーザー ({user_name}) の最新活動記録が見つかりませんでした。")
-                    processed_user_interactions_this_session.add((user_profile_url_clean, 'domo_latest'))
-                else:
-                    logger.info(f"ユーザー ({user_name}) の最新投稿へのDOMOは既に試行済みです。")
-            else:
-                logger.info(f"DOMOユーザー ({user_name}) の最新活動記録へのDOMOは設定で無効です。")
-
-            time.sleep(mpi_settings.get("delay_between_user_interaction_sec", 3.0))
-
-        logger.info(f"--- 活動記録 ({activity_id_log}) のDOMOユーザーへのインタラクションを終了 ---")
-
-    logger.info(f"<<< 自分の投稿へのDOMOユーザーインタラクション機能完了。")
-    logger.info(f"  合計フォローバック数: {total_followed_back_count}")
-    logger.info(f"  合計DOMO成功数（DOMOユーザーへ）: {total_domoed_to_users_count}")
-    return total_followed_back_count, total_domoed_to_users_count
+# The function interact_with_domo_users_on_my_posts has been removed as its functionality
+# is superseded by domo_back_to_past_domo_users.
 
 
 def _domo_back_and_follow_task(user_profile_url, user_name_for_log, shared_cookies, current_user_id_for_task, db_settings, sf_settings, ad_settings):

--- a/yamap_auto/yamap_auto_domo.py
+++ b/yamap_auto/yamap_auto_domo.py
@@ -80,7 +80,7 @@ from .search_utils import search_follow_and_domo_users
 from .follow_back_utils import follow_back_users_new
 # my_post_interaction_utils から必要なものをインポート
 from .my_post_interaction_utils import (
-    interact_with_domo_users_on_my_posts,
+    # interact_with_domo_users_on_my_posts, # Removed
     domo_back_to_past_domo_users # 新機能の関数をインポート
 )
 
@@ -147,7 +147,7 @@ try:
     TIMELINE_DOMO_SETTINGS = main_config.get("timeline_domo_settings", {})
     SEARCH_AND_FOLLOW_SETTINGS = main_config.get("search_and_follow_settings", {})
     PARALLEL_PROCESSING_SETTINGS = main_config.get("parallel_processing_settings", {})
-    MY_POST_INTERACTION_SETTINGS = main_config.get("new_feature_my_post_interaction", {})
+    # MY_POST_INTERACTION_SETTINGS = main_config.get("new_feature_my_post_interaction", {}) # Removed
     UNFOLLOW_INACTIVE_SETTINGS = main_config.get("unfollow_inactive_users_settings", {}) # 新機能の設定読み込み
 
     # 主要な設定セクションの存在確認 (UNFOLLOW_INACTIVE_SETTINGS も対象に追加)
@@ -156,7 +156,7 @@ try:
         TIMELINE_DOMO_SETTINGS,
         SEARCH_AND_FOLLOW_SETTINGS,
         PARALLEL_PROCESSING_SETTINGS,
-        MY_POST_INTERACTION_SETTINGS,
+        # MY_POST_INTERACTION_SETTINGS, # Removed
         UNFOLLOW_INACTIVE_SETTINGS
     ]
     essential_setting_names = [
@@ -164,7 +164,7 @@ try:
         "timeline_domo_settings",
         "search_and_follow_settings",
         "parallel_processing_settings",
-        "new_feature_my_post_interaction",
+        # "new_feature_my_post_interaction", # Removed
         "unfollow_inactive_users_settings"
     ]
 
@@ -272,9 +272,9 @@ def execute_main_tasks(driver, user_id, shared_cookies):
         'timeline_domo': 0,
         'search_followed': 0,
         'search_domoed': 0,
-        'my_post_followed_back': 0,
-        'my_post_domoed_to_user': 0,
-        'domo_back_to_past_users': 0, # 新機能のサマリー用キーを追加
+        # 'my_post_followed_back': 0, # Removed
+        # 'my_post_domoed_to_user': 0, # Removed
+        'domo_back_to_past_users': 0,
         'unfollowed_inactive': 0
     }
     if not driver:
@@ -326,21 +326,8 @@ def execute_main_tasks(driver, user_id, shared_cookies):
     else:
         logger.info("検索結果からのフォロー＆DOMO機能は設定で無効です。")
 
-    # 自分自身の投稿へのDOMOユーザーインタラクション機能
-    # この機能は MY_POST_INTERACTION_SETTINGS を直接参照するため、ここで main_config から読み込む必要はない
-    # my_post_interaction_utils 内部で _get_my_post_interaction_settings() を使って取得する
-    if MY_POST_INTERACTION_SETTINGS.get("enable_my_post_interaction", False): # main_configから直接有効性を確認
-        start_time = time.time()
-        logger.info("自分の投稿へのDOMOユーザーインタラクション機能を呼び出します。")
-        # interact_with_domo_users_on_my_posts は (followed_count, domoed_count) を返す
-        mpi_followed_count, mpi_domoed_count = interact_with_domo_users_on_my_posts(driver, user_id, shared_cookies)
-        summary_counts['my_post_followed_back'] = mpi_followed_count
-        summary_counts['my_post_domoed_to_user'] = mpi_domoed_count
-        end_time = time.time()
-        logger.info(f"自分の投稿へのDOMOユーザーインタラクション機能の処理時間: {end_time - start_time:.2f}秒。")
-        logger.info(f"  インタラクションによるフォローバック数: {mpi_followed_count}, DOMOユーザーへのDOMO数: {mpi_domoed_count}")
-    else:
-        logger.info("自分の投稿へのDOMOユーザーインタラクション機能は設定で無効です。")
+    # 自分自身の投稿へのDOMOユーザーインタラクション機能は削除されました。
+    # new_feature_domo_back_to_past_domo_users がその役割を包含します。
 
     # 非アクティブユーザーのアンフォロー機能
     if UNFOLLOW_INACTIVE_SETTINGS.get("enable_unfollow_inactive", False):
@@ -631,9 +618,9 @@ def main():
                 logger.info(f"  タイムラインDOMO数: {summary.get('timeline_domo', 0)} 件")
                 logger.info(f"  検索からの新規フォロー数: {summary.get('search_followed', 0)} 件")
                 logger.info(f"  検索からのDOMO数 (フォロー後): {summary.get('search_domoed', 0)} 件")
-                logger.info(f"  自分の投稿へのインタラクション - フォローバック数: {summary.get('my_post_followed_back', 0)} 件")
-                logger.info(f"  自分の投稿へのインタラクション - DOMOユーザーへのDOMO数: {summary.get('my_post_domoed_to_user', 0)} 件")
-                logger.info(f"  過去記事DOMOユーザーへのDOMO返し数: {summary.get('domo_back_to_past_users', 0)} 件") # 新機能のサマリー出力
+                # logger.info(f"  自分の投稿へのインタラクション - フォローバック数: {summary.get('my_post_followed_back', 0)} 件") # Removed
+                # logger.info(f"  自分の投稿へのインタラクション - DOMOユーザーへのDOMO数: {summary.get('my_post_domoed_to_user', 0)} 件") # Removed
+                logger.info(f"  過去記事DOMOユーザーへのDOMO返し数: {summary.get('domo_back_to_past_users', 0)} 件")
                 logger.info(f"  非アクティブユーザーのアンフォロー数: {summary.get('unfollowed_inactive', 0)} 件")
             else:
                 logger.info("  サマリー情報の取得に失敗しました。")


### PR DESCRIPTION
The feature `new_feature_my_post_interaction` was found to be a functional subset of `new_feature_domo_back_to_past_domo_users`.

This commit removes `new_feature_my_post_interaction` and its related code from configuration, utility functions, and the main script to simplify the codebase and eliminate redundancy.