### PR TITLE
Enable switches at the top level of config.yaml to be effective

### DIFF
--- a/yamap_auto/my_post_interaction_utils.py
+++ b/yamap_auto/my_post_interaction_utils.py
@@ -571,11 +571,12 @@ def domo_back_to_past_domo_users(driver, current_user_id, shared_cookies):
         tuple[int, int]: フォローしたユーザーの総数と、DOMO返しに成功した総数。
                          (total_followed_count, total_domoed_back_count)
     """
-    db_settings = _get_domo_back_settings()
-    if not db_settings.get("enable_domo_back_to_past_users", False):
-        logger.info("過去記事DOMOユーザーへのDOMO返し機能は設定で無効です。")
-        return 0, 0 # フォロー数とDOMO数を返すように変更
+    config = _get_config_cached() # main_config全体を取得
+    if not config.get("enable_domo_back_to_past_users", False): # トップレベルのキーを参照
+        logger.info("過去記事DOMOユーザーへのDOMO返し機能は設定で無効です。 (トップレベル設定による)")
+        return 0, 0 # フォロー数とDOMO数を返す
 
+    db_settings = _get_domo_back_settings() # 詳細設定は引き続き専用セクションから取得
     sf_settings = _get_search_follow_settings_for_domo_back() # フォロー条件用
     ad_settings = _get_action_delays_mpi() # アクション遅延用
 

--- a/yamap_auto/yamap_auto_domo.py
+++ b/yamap_auto/yamap_auto_domo.py
@@ -364,19 +364,18 @@ def execute_main_tasks(driver, user_id, shared_cookies):
         logger.info("非アクティブユーザーのアンフォロー機能は設定で無効です。")
 
     # === 過去記事DOMOユーザーへのDOMO返し機能 ===
-    # この設定は my_post_interaction_utils 内部で config から読み込まれるが、
-    # ここでは main_config を使って有効無効を判定し、呼び出しを制御する。
-    # new_feature_domo_back_to_past_domo_users セクションを main_config から取得
-    domo_back_settings = main_config.get("new_feature_domo_back_to_past_domo_users", {})
-    if domo_back_settings.get("enable_domo_back_to_past_users", False):
+    # 機能の有効/無効はトップレベルの `enable_domo_back_to_past_users` で判定
+    if main_config.get("enable_domo_back_to_past_users", False):
         start_time = time.time()
         logger.info("過去記事DOMOユーザーへのDOMO返し機能を呼び出します。")
-        domo_back_count = domo_back_to_past_domo_users(driver, user_id, shared_cookies)
+        # domo_back_to_past_domo_users 関数は (followed_count, domoed_count) を返すように変更されているため、両方受け取る
+        followed_count, domo_back_count = domo_back_to_past_domo_users(driver, user_id, shared_cookies)
         summary_counts['domo_back_to_past_users'] = domo_back_count
+        # summary_counts にフォロー数を記録する項目は現状ないが、ログには出力する
         end_time = time.time()
-        logger.info(f"過去記事DOMOユーザーへのDOMO返し機能の処理時間: {end_time - start_time:.2f}秒。DOMO返し成功数: {domo_back_count}")
+        logger.info(f"過去記事DOMOユーザーへのDOMO返し機能の処理時間: {end_time - start_time:.2f}秒。DOMO返し成功数: {domo_back_count}, フォロー成功数: {followed_count}")
     else:
-        logger.info("過去記事DOMOユーザーへのDOMO返し機能は設定で無効です。")
+        logger.info("過去記事DOMOユーザーへのDOMO返し機能は設定で無効です。 (トップレベル設定による)")
 
     return summary_counts
 


### PR DESCRIPTION
I modified yamap_auto_domo.py and my_post_interaction_utils.py to read the enable_domo_back_to_past_users setting from the top level of config.yaml, as per your request.

Detailed settings for the feature are still expected to be in the new_feature_domo_back_to_past_domo_users section.