### PR TITLE
FIX: Add TRACE logging level and method

### DIFF
--- a/yamap_auto/logging_utils.py
+++ b/yamap_auto/logging_utils.py
@@ -2,6 +2,17 @@
 import logging
 import os
 
+# Define TRACE logging level
+TRACE = 5
+logging.addLevelName(TRACE, "TRACE")
+
+def trace(self, message, *args, **kws):
+    # Yes, logger takes its '*args' as 'args'.
+    if self.isEnabledFor(TRACE):
+        self._log(TRACE, message, args, **kws)
+
+logging.Logger.trace = trace
+
 # LOG_FILE_NAME = "yamap_auto_domo.log"  # ログファイル名（メインスクリプトと同じ場所に出力想定）
 # logs ディレクトリ以下に出力するように変更
 LOG_BASE_NAME = "yamap_auto_domo.log"


### PR DESCRIPTION
This change introduces a TRACE logging level (5) and adds a corresponding `trace` method to `logging.Logger`.

This resolves an AttributeError that occurred when `logger.trace()` was called, as the `trace` method was previously undefined.