### PR TITLE
Fix: Correct WebDriver settings and User-Agent configuration

### DIFF
--- a/yamap_auto/config.yaml
+++ b/yamap_auto/config.yaml
@@ -29,6 +29,16 @@ implicit_wait_sec: 5
 # Selenium WebDriverが要素を見つけるまでの暗黙的な最大待機時間 (秒単位)
 # ページ要素の読み込みが遅い場合に、この時間まで待機します。
 
+# === WebDriver設定 ===
+webdriver_settings:
+  user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36"
+  # WebDriverが使用するUser-Agent文字列。空文字にするとWebDriverのデフォルトを使用します。
+  # YAMAPが特定のUser-Agentをブロックする場合などに変更を検討してください。
+  implicit_wait_sec: 7 # driver_utils.py 内の create_driver_with_cookies で使用されるため、config.yaml にも定義
+  # この implicit_wait_sec は create_driver_with_cookies 内で driver.implicitly_wait() に渡される値です。
+  # ルートレベルの implicit_wait_sec はメインスクリプト (yamap_auto_domo.py) の初期WebDriver用です。
+  # 必要に応じて値を調整してください。
+
 # === アクション共通の遅延設定 ===
 # DOMOやフォローなど、特定のアクション実行後や要素待機時の共通の遅延時間を設定します。
 # これらはサーバーへの負荷軽減や、UIの反応待ちを目的としています。

--- a/yamap_auto/driver_utils.py
+++ b/yamap_auto/driver_utils.py
@@ -182,16 +182,16 @@ def get_driver_options():
     main_conf = get_main_config() # 設定を確実にロード
     options = webdriver.ChromeOptions()
 
-    # webdriver_settings = main_conf.get("webdriver_settings", {}) # この行を削除またはコメントアウト
-
-    if main_conf.get("headless_mode", False): # ルートレベルの headless_mode を参照
+    # headless_mode はルートレベルから取得
+    if main_conf.get("headless_mode", False):
         logger.info("ヘッドレスモードで起動します。")
         options.add_argument('--headless')
         options.add_argument('--disable-gpu')
         options.add_argument('--window-size=1920,1080')
 
-    # 新規追加: User-Agentの設定
-    user_agent_string = webdriver_settings.get("user_agent")
+    # User-Agent は webdriver_settings から取得
+    webdriver_settings_conf = main_conf.get("webdriver_settings", {})
+    user_agent_string = webdriver_settings_conf.get("user_agent")
     if user_agent_string:
         logger.info(f"指定されたUser-Agentを使用します: {user_agent_string}")
         options.add_argument(f"user-agent={user_agent_string}")


### PR DESCRIPTION
- I added a `webdriver_settings` section to `config.yaml` to define `user_agent` and `implicit_wait_sec` used by `create_driver_with_cookies`.
- I modified `get_driver_options` in `driver_utils.py` to:
  - Load `user_agent` from `webdriver_settings.user_agent` in `config.yaml`.
  - Continue loading `headless_mode` from the root level of `config.yaml`.
- This resolves the NameError for `webdriver_settings` and ensures proper configuration loading for both headless mode and User-Agent.