### PR TITLE
feat: HTTPエンドポイント経由での処理開始機能を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ WORKDIR /app
 COPY . /app
 
 # 依存パッケージ
-RUN pip install --no-cache-dir selenium PyYAML
+RUN pip install --no-cache-dir -r requirements.txt
 
-CMD ["python", "-m", "yamap_auto.yamap_auto_domo"]
+# アプリケーションのポートを公開 (任意だが推奨)
+EXPOSE 8080
+
+CMD ["gunicorn", "--bind", "0.0.0.0:8080", "main:app"]

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -8,17 +8,16 @@ steps:
   - name: 'gcr.io/cloud-builders/gcloud'
     args:
       - run
-      - jobs
-      - deploy
-      - yamap-auto-domo-follow
+      - deploy # 'jobs deploy' から 'deploy' に変更
+      - yamap-auto-domo-follow # サービス名
       - --image=gcr.io/$PROJECT_ID/yamap-auto-domo-follow
       - --region=asia-northeast1
+      - --platform=managed # プラットフォームを指定
+      - --port=8080 # コンテナがリッスンするポート
+      - --allow-unauthenticated # 公開アクセスを許可 (必要に応じて変更)
       - --set-secrets=_YAMAP_LOGIN_ID=gcp-secret-yamap-id:latest,_YAMAP_LOGIN_PASSWORD=gcp-secret-yamap-password:latest
       - --memory=1Gi
-      - --task-timeout=900s
-      - --max-retries=1
-      - --command=python
-      - --args=-m,yamap_auto.yamap_auto_domo
+      # --task-timeout, --max-retries, --command, --args はServiceデプロイでは通常不要または異なる方法で設定
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/main.py
+++ b/main.py
@@ -1,0 +1,52 @@
+import threading
+from flask import Flask, jsonify
+import logging
+
+# yamap_auto.yamap_auto_domo が存在するかどうかを確認し、存在すればインポート
+# これは、yamap_auto が PYTHONPATH にあるか、同じディレクトリ構造内にあることを前提としています。
+try:
+    from yamap_auto import yamap_auto_domo
+except ImportError as e:
+    logging.error(f"yamap_auto.yamap_auto_domoのインポートに失敗しました: {e}")
+    # インポートに失敗した場合、アプリケーションは起動するが /start エンドポイントは機能しない
+    # 適切なエラーハンドリングや設定が必要
+    yamap_auto_domo = None
+
+app = Flask(__name__)
+
+# ロガー設定
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# yamap_auto_domo.main() を実行するためのワーカー関数
+def run_yamap_auto_domo():
+    if yamap_auto_domo:
+        try:
+            logger.info("yamap_auto_domo.main() の実行を開始します。")
+            yamap_auto_domo.main()
+            logger.info("yamap_auto_domo.main() の実行が完了しました。")
+        except Exception as e:
+            logger.error(f"yamap_auto_domo.main() の実行中にエラーが発生しました: {e}", exc_info=True)
+    else:
+        logger.error("yamap_auto_domoモジュールがロードされていないため、処理を実行できません。")
+
+@app.route('/start', methods=['GET'])
+def start_process():
+    logger.info("/start エンドポイントが呼び出されました。")
+
+    # バックグラウンドスレッドで yamap_auto_domo.main を実行
+    thread = threading.Thread(target=run_yamap_auto_domo)
+    thread.daemon = True # アプリケーション終了時にスレッドも終了させる
+    thread.start()
+
+    logger.info("yamap_auto_domo.main() のバックグラウンド実行を開始しました。")
+    return jsonify({"message": "処理をバックグラウンドで開始しました。"}), 200
+
+@app.route('/', methods=['GET'])
+def health_check():
+    logger.info("/ (ヘルスチェック) エンドポイントが呼び出されました。")
+    return jsonify({"status": "healthy"}), 200
+
+if __name__ == '__main__':
+    #開発用サーバー。本番環境ではgunicornを使用します。
+    app.run(host='0.0.0.0', port=8080, debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+gunicorn
+selenium
+PyYAML


### PR DESCRIPTION
- FlaskとGunicornを導入し、HTTPサーバーを構築。
- /start エンドポイントを設け、GETリクエストで yamap_auto_domo.main() をバックグラウンド実行するようにした。
- DockerfileのCMDをgunicornによるFlaskアプリ起動に変更。
- cloudbuild.ymlをCloud Run Serviceデプロイ用に更新。