### PR TITLE
fix: モジュールインポートエラーの修正

### DIFF
--- a/yamap_auto/__init__.py
+++ b/yamap_auto/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Python treat the 'yamap_auto' directory as a package.


### PR DESCRIPTION
- yamap_auto ディレクトリに __init__.py を追加し、 パッケージとして正しく認識されるようにしました。
- これにより、main.py から yamap_auto.yamap_auto_domo の インポートが Cloud Run 環境でも成功するはずです。