### PR TITLE
fix: bs4モジュール不足エラーの解消

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask
 gunicorn
 selenium
 PyYAML
+beautifulsoup4


### PR DESCRIPTION
- requirements.txt に beautifulsoup4 を追加。
- これにより、yamap_auto_domo およびその依存モジュールが 必要とする bs4 (Beautiful Soup 4) が利用可能になる。