### PR TITLE
I've fixed the Cloud Run startup error.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,15 +44,13 @@ RUN pip install --no-cache-dir -r requirements.txt
 # アプリケーションコードのコピー
 COPY . .
 
-# Cloud Functions の場合、CMD や EXPOSE は通常不要です。
-# Google Cloud Functions は、デプロイ時に指定されたエントリーポイント（例: main.run_yamap_auto_domo_function）を
-# 直接呼び出します。
-# EXPOSE 8080
-# CMD ["gunicorn", "--bind", "0.0.0.0:8080", "--workers=1", "main:app"]
+# Gunicorn を使用してアプリケーションを起動します。
+# Cloud Run は PORT 環境変数でリッスンするポートを指定します。
+# Gunicorn はワーカーを1つ、スレッドを8つ持つように設定し、タイムアウトを延長します。
+# ログは標準出力に直接出すように設定します。
+EXPOSE 8080
+CMD ["gunicorn", "--bind", "0.0.0.0:8080", "--workers=1", "--threads=8", "--timeout=300", "main:app", "--log-level=info", "--log-file=-"]
 
 # 環境変数 (オプション、必要に応じて設定)
 # 例: ENV GOOGLE_APPLICATION_CREDENTIALS /app/credentials.json
 ENV PYTHONUNBUFFERED TRUE
-
-# main.py 内の関数が呼び出されることを想定
-# Cloud Functionsのデプロイ時にエントリーポイントとして `run_yamap_auto_domo_function` を指定

--- a/main.py
+++ b/main.py
@@ -6,51 +6,89 @@ from yamap_auto import yamap_auto_domo
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-def run_yamap_auto_domo_function(request): # 引数を request に変更
-    """
-    Cloud Functionsのエントリーポイント (HTTPトリガー用)。
-    Cloud Schedulerから呼び出されることを想定しています。
-    """
-    # request オブジェクトから情報を取得する場合の例 (今回は特に使用しない想定)
-    # request_json = request.get_json(silent=True)
-    # request_args = request.args
-    logger.info(f"Cloud Function 'run_yamap_auto_domo_function' triggered. Request method: {request.method}, Headers: {request.headers}")
+import threading
+from flask import Flask, jsonify
 
+# ロガー設定
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = Flask(__name__)
+
+# --- グローバル変数 ---
+# 処理の状態を管理するための変数
+# simple: 'idle', 'running', 'completed', 'error'
+# detailed: 'idle', 'initializing', 'logging_in', 'executing_tasks', 'completed', 'error'
+processing_status = {"simple": "idle", "detailed": "idle", "error_message": None}
+processing_thread = None
+
+def run_automation_in_background():
+    """
+    yamap_auto_domo.main() をバックグラウンドで実行するためのラッパー関数。
+    グローバルなステータス変数を更新します。
+    """
+    global processing_status
     try:
+        logger.info("バックグラウンド処理を開始します...")
+        processing_status["simple"] = "running"
+        processing_status["detailed"] = "initializing"
+
         # yamap_auto_domo.main() を直接呼び出す
-        # 必要に応じて、設定ファイルや環境変数をここで処理することもできます。
-        # 例: config_path = os.environ.get("CONFIG_PATH", "yamap_auto/config.yaml")
-        #     yamap_auto_domo.main(config_path=config_path)
-
-        logger.info("yamap_auto_domo.main() の実行を開始します。")
         yamap_auto_domo.main()
-        logger.info("yamap_auto_domo.main() の実行が完了しました。")
-        # HTTPレスポンスとして文字列とステータスコードを返す
-        return "Function execution completed successfully.", 200
-    except Exception as e:
-        logger.error(f"yamap_auto_domo.main() の実行中にエラーが発生しました: {e}", exc_info=True)
-        return f"Error during function execution: {e}", 500
 
-# 従来のFlaskアプリ部分はCloud Functionsでは不要なためコメントアウトまたは削除
-# from flask import Flask, jsonify
-# app = Flask(__name__)
-#
-# @app.route('/start', methods=['GET'])
-# def start_process():
-#     logger.info("/start エンドポイントが呼び出されました。")
-#     # Cloud FunctionsではHTTPリクエストごとに独立して実行されるため、
-#     # バックグラウンドスレッドは通常不要です。
-#     # Schedulerが直接エントリーポイント関数を呼び出します。
-#     run_yamap_auto_domo_function(None, None) # 直接実行する場合の例
-#     return jsonify({"message": "処理を開始しました。"}), 200
-#
-# @app.route('/', methods=['GET'])
-# def health_check():
-#     logger.info("/ (ヘルスチェック) エンドポイントが呼び出されました。")
-#     return jsonify({"status": "healthy"}), 200
-#
-# if __name__ == '__main__':
-#     # Cloud Functions環境では、この部分は実行されません。
-#     # ローカルでのテスト用に残すか、削除します。
-#     # app.run(host='0.0.0.0', port=8080, debug=True)
-#     pass
+        logger.info("バックグラウンド処理が正常に完了しました。")
+        processing_status["simple"] = "completed"
+        processing_status["detailed"] = "completed"
+
+    except Exception as e:
+        logger.error(f"バックグラウンド処理中にエラーが発生しました: {e}", exc_info=True)
+        processing_status["simple"] = "error"
+        processing_status["detailed"] = "error"
+        # エラーメッセージを保存（簡潔なもの）
+        processing_status["error_message"] = str(e)
+
+
+@app.route('/start', methods=['POST'])
+def start_process():
+    """
+    自動化処理を開始するエンドポイント。
+    既に処理が実行中の場合はエラーを返します。
+    """
+    global processing_thread, processing_status
+    logger.info("/start エンドポイントが呼び出されました。")
+
+    if processing_thread and processing_thread.is_alive():
+        logger.warning("既に処理が実行中です。")
+        return jsonify({"status": "error", "message": "処理は既に実行中です。", "details": processing_status}), 409 # 409 Conflict
+
+    # ステータスをリセットして新しいスレッドを開始
+    processing_status = {"simple": "idle", "detailed": "idle", "error_message": None}
+    processing_thread = threading.Thread(target=run_automation_in_background)
+    processing_thread.start()
+
+    logger.info("新しいバックグラウンド処理を開始しました。")
+    return jsonify({"status": "success", "message": "処理を開始しました。", "details": processing_status}), 202 # 202 Accepted
+
+@app.route('/status', methods=['GET'])
+def get_status():
+    """
+    現在の処理状況を返すエンドポイント。
+    """
+    logger.info("/status エンドポイントが呼び出されました。")
+    return jsonify({"status": "ok", "processing_status": processing_status})
+
+
+@app.route('/', methods=['GET'])
+def health_check():
+    """
+    ヘルスチェック用のエンドポイント。
+    Cloud Runがコンテナの起動を確認するために使用します。
+    """
+    logger.info("/ (ヘルスチェック) エンドポイントが呼び出されました。")
+    return jsonify({"status": "healthy"}), 200
+
+if __name__ == '__main__':
+    # Cloud Run環境では、PORT環境変数がGunicornによって使用されます。
+    # この部分は主にローカルでのデバッグ実行用です。
+    port = int(os.environ.get("PORT", 8080))
+    app.run(host='0.0.0.0', port=port, debug=True)


### PR DESCRIPTION
The container was failing to start because it wasn't listening on the port specified by the `PORT` environment variable. This was because the application was designed as a script to be run on a schedule, not as a web server.

This change introduces a Flask web server that listens on the correct port and exposes an endpoint to trigger the web scraping process. This will allow the container to start up correctly in the Cloud Run environment.