### PR TITLE
I've added a sequential processing configuration and enabled switchin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ YAMAPへのログインに必要な以下の情報は、すべて環境変数を
 -   **`YAMAP_LOGIN_ID`**: YAMAPのログインに使用するメールアドレス。
 -   **`YAMAP_LOGIN_PASSWORD`**: YAMAPのログインに使用するパスワード。
 -   **`USER_ID`**: あなたのYAMAPユーザーID。
+-   **`YAMAP_CONFIG_FILE`**: (オプション) 使用する設定ファイルを指定します。デフォルトは `yamap_auto/config.yaml` です。`yamap_auto/config_sequential.yaml` を指定すると、並列処理を無効にした設定で実行できます。
 
 これらの環境変数は、`jules.yml` で定義されており、Google Secret Managerに保存されたシークレットから読み込まれます。
 ローカルで実行する場合は、これらの環境変数を手動で設定してください。

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -19,6 +19,8 @@ steps:
       - --memory=1Gi # Headless Chrome はメモリを消費するため
       # 環境変数はSecret Manager経由で設定
       - --set-secrets=YAMAP_LOGIN_ID=gcp-secret-yamap-id:latest,YAMAP_LOGIN_PASSWORD=gcp-secret-yamap-password:latest,YAMAP_USER_ID=gcp-secret-yamap-user-id:latest
+      # 使用する設定ファイルを環境変数で指定
+      - --update-env-vars=YAMAP_CONFIG_FILE=yamap_auto/config_sequential.yaml
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/yamap_auto/config_sequential.yaml
+++ b/yamap_auto/config_sequential.yaml
@@ -1,0 +1,265 @@
+# === 機能の有効化/無効化 ===
+enable_follow_back: true
+# true: フォローバック機能を有効にします。
+# false: フォローバック機能を無効にします。
+enable_timeline_domo: true
+# true: タイムラインDOMO機能を有効にします。
+# false: タイムラインDOMO機能を無効にします。
+enable_search_and_follow: true
+# true: 検索結果からのフォロー＆DOMO機能を有効にします。
+# false: 機能を無効にします。
+enable_domo_back_to_past_users: true
+# true: 過去記事DOMOユーザーへの最新記事DOMO返し機能を有効にします。
+# false: この機能を無効にします。
+enable_unfollow_inactive: true
+# true: 非アクティブかつ非相互フォローユーザーのアンフォロー機能を有効にします。
+# false: この機能を無効にします。
+enable_parallel_processing: false
+# true: 並列処理を有効にします (現在はタイムラインDOMO機能が対象)。
+# false: 並列処理を無効にし、全ての処理を逐次実行します。
+
+# === 全体的な設定 ===
+# スクリプト全体の基本的な動作モードや待機時間を設定します。
+
+headless_mode: true
+# ブラウザをヘッドレスモードで実行するかどうか (true: ヘッドレス, false: 通常モード)
+# ヘッドレスモードではブラウザウィンドウは表示されませんが、バックグラウンドで動作します。デバッグ時は false が推奨されます。
+
+implicit_wait_sec: 5
+# Selenium WebDriverが要素を見つけるまでの暗黙的な最大待機時間 (秒単位)
+# ページ要素の読み込みが遅い場合に、この時間まで待機します。
+
+# === WebDriver設定 ===
+webdriver_settings:
+  # "local" または "docker_container"
+  execution_environment: "local"
+  # local: ローカル環境で実行。ChromeDriverはシステムPATHにあるか、`chromedriver_path`で指定。
+  # docker_container: Dockerコンテナ内で実行。ChromeDriverはコンテナ内の期待されるパスにある想定。
+
+  chromedriver_path: "" # ローカル実行時、ChromeDriverの実行ファイルへの絶対パス。空の場合、システムPATHから探す。
+  # 例: "C:/path/to/chromedriver.exe" や "/usr/local/bin/chromedriver"
+
+  chrome_binary_location: "" # ヘッドレスモードや特定環境でChrome/Chromiumのバイナリパスを明示的に指定する場合
+  # Dockerコンテナ内ではDockerfileで設定されたパス (例: /usr/bin/google-chrome-stable や /usr/bin/chromium) を
+  # driver_utils.py側で自動的に設定するよう試みるため、通常は空で良い。
+  # ローカルで特殊な場所にChromeをインストールしている場合に指定。
+
+  user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36"
+  # WebDriverが使用するUser-Agent文字列。空文字にするとWebDriverのデフォルトを使用します。
+  # YAMAPが特定のUser-Agentをブロックする場合などに変更を検討してください。
+  implicit_wait_sec: 7 # driver_utils.py 内の create_driver_with_cookies で使用されるため、config.yaml にも定義
+  # この implicit_wait_sec は create_driver_with_cookies 内で driver.implicitly_wait() に渡される値です。
+  # ルートレベルの implicit_wait_sec はメインスクリプト (yamap_auto_domo.py) の初期WebDriver用です。
+  # 必要に応じて値を調整してください。
+
+# === アクション共通の遅延設定 ===
+# DOMOやフォローなど、特定のアクション実行後や要素待機時の共通の遅延時間を設定します。
+# これらはサーバーへの負荷軽減や、UIの反応待ちを目的としています。
+
+action_delays:
+  after_domo_sec: 1.5
+  # DOMO操作を実行した後に挿入される共通の待機時間 (秒単位)
+  # DOMO後のUI反映や次のアクションへの移行をスムーズにするために使用されます。
+
+  wait_for_activity_link_sec: 7
+  # ユーザープロフィールページなどで、最新の活動日記へのリンクが表示されるまでの最大待機時間 (秒単位)
+  # ページコンテンツの動的な読み込みに対応するために使用されます。
+
+  after_follow_action_sec: 1.0
+  # フォロー/フォローバック操作を実行した後に挿入される共通の待機時間 (秒単位)
+  # フォロー状態のUI反映や、連続したフォロー操作間のインターバルとして機能します。
+
+# === 並列処理設定 (全体) ===
+# スクリプト内の一部の処理（現在はタイムラインDOMOなど）を並列実行するための共通設定です。
+# 各機能の並列処理を有効にするかは、各機能の設定 (`enable_parallel_...`) で制御します。
+# 注意: 並列処理はアカウントの安全性やYAMAPの利用規約に影響を与える可能性があるため、慎重に使用してください。
+#       過度な並列化は短時間に多くのリクエストを送信することになり、一時的なアクセス制限のリスクを高める可能性があります。
+parallel_processing_settings:
+  max_workers: 1
+  # 並列処理に使用する最大ワーカー（スレッド）数。
+  # PCのスペックやネットワーク環境に応じて調整してください。推奨値は 2〜5 程度です。
+  # 大きすぎる値を設定すると、かえってパフォーマンスが低下したり、アカウントへの負荷が高まる可能性があります。
+
+  use_cookie_sharing: false
+  # true: ログイン時に取得したセッションCookieを、並列実行される各ワーカー（ブラウザインスタンス）で共有しようと試みます。
+  #       これにより、各ワーカーが個別にログイン処理を行う必要がなくなります。
+  # false: Cookie共有を行いません (各ワーカーが独立して動作しようとしますが、ログインが必要な操作は失敗する可能性があります)。
+
+  delay_between_thread_tasks_sec: 0.5 # (変更) 1.0秒から短縮
+  # 各並列タスク（例: 個別のDOMO処理）を開始する前に挿入される基本的な遅延時間 (秒単位)。
+  # これに加えて、スクリプト内でタスクごとに僅かな追加遅延が加えられることがあります。
+  # 同時アクセスを緩和し、サーバー負荷を軽減することを目的としています。
+
+follow_back_settings:
+  # フォローバック機能に関する設定 (自分をフォローしてくれたユーザーを自動でフォローバックする)
+  max_users_to_follow_back: 20
+  # 一度のスクリプト実行でフォローバックする最大のユーザー数。
+  # フォロワーリストの複数ページをチェックする場合、この合計数に達すると処理を停止します。
+
+  max_pages_for_follow_back: 10
+  # フォローバック対象者を探すために、フォロワーリストの何ページ目まで確認するかを指定します。
+  # 例えば `5` を指定すると、最新のフォロワーから最大5ページ分遡って確認します。
+
+  enable_parallel_follow_back: false
+  # true: フォローバック機能の並列処理を有効にします。
+  # false: 従来の逐次処理を実行します。
+
+  max_workers_follow_back: 1
+  # フォローバック機能を並列処理する場合の最大ワーカー（スレッド）数。
+  # enable_parallel_follow_back が true の場合に参照されます。
+
+  delay_per_worker_action_sec: 1.5 # (変更) 2.5秒から短縮
+  # 並列フォローバック時、各ワーカースレッドがフォローアクションを実行した後の個別の遅延時間 (秒単位)。
+  # 逐次処理の場合は action_delays.after_follow_action_sec が使用されます。
+
+  # 従来の逐次処理でのフォローバック実行後の待機時間は `action_delays.after_follow_action_sec` を参照します。
+
+timeline_domo_settings:
+  # タイムラインDOMO機能に関する設定 (YAMAPのタイムライン上の活動記録に自動でDOMOする)
+  max_activities_to_domo_on_timeline: 20
+  # タイムライン上でDOMOする活動記録の最大数。
+  # タイムラインの新しい投稿から順に、この数に達するまでDOMOを試みます。
+
+  # タイムラインでの各DOMO実行後の待機時間は `action_delays.after_domo_sec` を参照します。
+
+search_and_follow_settings:
+  # 活動記録検索ページからのフォロー＆DOMO機能に関する設定
+  search_activities_url: "https://yamap.com/search/activities"
+  # 処理を開始する活動記録の検索結果ページのURL。
+  # 通常はデフォルトのままで問題ありませんが、特定の検索条件で開始したい場合にカスタマイズ可能です。
+
+  max_pages_to_process_search: 2
+  # 検索結果の何ページ目まで処理を続けるかを指定します。
+  # 例えば `3` を指定すると、最初のページから3ページ目まで処理します。
+
+  max_users_to_process_per_page: 24
+  # 検索結果の各ページで、最大何人のユーザー（活動記録の投稿者）を処理対象とするかを指定します。
+
+  min_followers_for_search_follow: 8
+  # フォローを検討するユーザーの最低フォロワー数。
+  # この数未満のフォロワーしか持たないユーザーは、フォローの対象外となります。
+
+  follow_ratio_threshold_for_search: 0.9
+  # フォローを検討する際の「相手のフォロー中ユーザー数 / 相手のフォロワー数」の比率の閾値。
+  # この比率が設定値以上のユーザー（つまり、フォロワー数に対してフォロー中の数が多いユーザー）をフォロー対象とします。
+  # 例えば `0.9` の場合、フォロー数がフォロワー数の90%以上のユーザーが対象です。
+
+  domo_latest_activity_after_follow: true
+  # true: 上記の条件でユーザーをフォローした後、そのユーザーの最新の活動記録にDOMOします。
+  # false: フォローのみ行い、DOMOはしません。
+
+  delay_between_user_processing_in_search_sec: 2.0
+  # 検索結果ページで一人のユーザーの処理（フォロー/DOMOまたはスキップ）が完了した後、
+  # 次のユーザーの処理を開始するまでの待機時間 (秒単位)。
+
+  delay_after_pagination_sec: 3.0
+  # 検索結果のページネーション（「次へ」ボタンクリックなど）を実行した後の待機時間 (秒単位)。
+  # 新しいページのコンテンツが完全に読み込まれるのを待つために使用します。
+
+  enable_parallel_search_follow: false
+  # true: 検索＆フォロー機能のユーザー処理部分（プロフィール確認、フォロー、DOMO）を並列化します。
+  #       メインスレッドが検索結果ページからユーザー情報を収集し、ワーカースレッド群が個別のユーザー処理を並行して行います。
+  # false: 従来の逐次処理を実行します（メインスレッドが一人ずつユーザー処理を行います）。
+  # 注意: YAMAPの利用規約やサーバー負荷を考慮し、自己責任で有効にしてください。短時間に多くのリクエストが発生する可能性があります。
+
+  max_workers_search_follow: 1
+  # 検索＆フォロー機能を並列処理する場合の最大ワーカー（スレッド）数。
+  # enable_parallel_search_follow が true の場合に参照されます。
+  # PCのCPUコア数やネットワーク帯域、対象サイトの応答性によって最適な値は異なります。
+  # 一般的には2〜5程度から試し、徐々に増やして様子を見ることを推奨します。
+  # 値を大きくしすぎると、リソース競合やYAMAPサーバーへの過度な負荷により、かえって性能が低下したり、
+  # アカウントが一時的に制限されるリスクが高まる可能性があります。
+
+  delay_per_worker_user_processing_sec: 2.0
+  # 並列検索＆フォロー時、各ワーカースレッドが1ユーザーの一連の処理（プロフ確認、フォロー、DOMOなど）を完了した後に挿入される個別の遅延時間 (秒単位)。
+  # 複数のワーカースレッドが同時にYAMAPへリクエストを送信するため、各アクション後に適切な遅延を入れることで、
+  # サーバーへの瞬間的な負荷を軽減し、安定した動作を目指します。
+  # この値が小さすぎると、YAMAPからの応答エラーやアカウント制限のリスクが高まる可能性があります。
+  # 逐次処理の場合は `delay_between_user_processing_in_search_sec` がユーザー間の遅延として使用されます。
+
+# === 新機能: 過去記事DOMOユーザーへの最新記事DOMO返し設定 ===
+new_feature_domo_back_to_past_domo_users:
+  max_days_to_check_past_activities: 7
+  # DOMO返しのためにチェックする自分の過去記事の期間（日数）。
+
+  max_past_activities_to_process: 10
+  # DOMO返しのために処理する自分の過去記事の最大数。
+  # 例: 期間内に10件の記事があっても、この値が5なら新しい方から5件のみ処理。
+
+  max_users_to_domo_back_per_activity: 100
+  # 1つの自分の過去記事あたり、DOMO返しを行うユーザーの最大数。
+
+  max_total_domo_back_users_per_run: 1000
+  # 1回のスクリプト実行でDOMO返しを行うユーザーの総最大数。
+
+  # --- DOMO返し時のフォロー設定 ---
+  enable_follow_during_domo_back: true
+  # true: DOMO返しを行う際、まだフォローしていなければ条件に基づいてフォローも試みます。
+  # false: DOMO返しのみ行い、フォローは試みません。
+  # フォロー条件 (最低フォロワー数、フォロー/フォロワー比率の閾値) は、
+  # `search_and_follow_settings` セクション内の
+  # `min_followers_for_search_follow` と `follow_ratio_threshold_for_search` の値を共通で利用します。
+
+  # --- DOMO返し時の条件 (従来のDOMOに関するもの) ---
+  enable_domo_only_if_not_following_me: false
+  # true: 自分をまだフォローしていないユーザーに限定してDOMO返しを行います。
+  # false: フォロー状況に関わらずDOMO返しを行います。
+
+  enable_domo_only_if_i_am_not_following: false
+  # true: 自分がまだフォローしていないユーザーに限定してDOMO返しを行います。
+  # false: 自分が既にフォローしているユーザーにもDOMO返しを行います。
+
+  # --- 並列処理設定 ---
+  enable_parallel_domo_back: false
+  # true: DOMO返し処理 (各ユーザーへのプロフィール確認、フォロー試行、最新記事へのDOMO) を並列実行します。
+  # false: 逐次処理を実行します。
+  # 注意: YAMAPの利用規約やサーバー負荷を考慮し、自己責任で有効にしてください。
+
+  max_workers_domo_back: 1
+  # 並列DOMO返し処理の最大ワーカー（スレッド）数。
+  # `enable_parallel_domo_back` が true の場合に参照されます。推奨: 2-3程度。
+
+  delay_per_worker_domo_back_sec: 2.5
+  # 並列DOMO返し時、各ワーカースレッドが1ユーザーの一連の処理を完了した後に挿入される遅延時間 (秒単位)。
+
+  # --- 逐次処理時の遅延 ---
+  delay_between_domo_back_action_sec: 3.0 # 逐次処理時のアクション間遅延
+  # `enable_parallel_domo_back` が false の場合、各ユーザーへのDOMO返しアクション間の遅延時間 (秒単位)。
+
+# === 新機能: 非アクティブかつ非相互フォローユーザーのアンフォロー設定 ===
+unfollow_inactive_users_settings:
+  inactive_threshold_days: 30
+  # ユーザーの活動がこの日数以上ない場合に「非アクティブ」と見なします。
+
+  max_users_to_unfollow_per_run: 10
+  # 1回のスクリプト実行でアンフォローする最大のユーザー数。
+  # 多数の対象者がいる場合に、一度に大量のアンフォローが発生するのを防ぎます。
+
+  check_if_following_back: true
+  # true: アンフォロー対象とするユーザーが、自分をフォローバックしているか確認します。
+  #       フォローバックされていないユーザーのみが対象となります。
+  # false: フォローバックの状況は確認せず、非アクティブなフォロー中ユーザー全てを対象とします。
+  # 注意: この確認処理は、ユーザーのフォロワーリストを取得・照合する必要があるため、
+  #       処理時間が増加する可能性があります。また、確実な判定が難しい場合があります。
+
+  delay_before_unfollow_action_sec: 2.0
+  # アンフォロー操作を実行する直前の待機時間 (秒単位)。
+
+  delay_after_unfollow_action_sec: 3.0
+  # アンフォロー操作を実行した後の待機時間 (秒単位)。UIの反映待ちや負荷軽減のため。
+
+  parallel_profile_page_workers: 1 # (追加) 非アクティブユーザーの最終活動日を取得する際の並列ワーカー数
+
+  enable_parallel_unfollow_action: false # (追加) アンフォローアクション自体の並列実行を有効にするか
+  max_workers_unfollow_action: 1     # (追加) アンフォローアクションの最大ワーカー数
+  delay_per_worker_unfollow_sec: 2.0  # (追加) 各アンフォローワーカースレッドのアクション後の遅延
+
+# === YAMAP認証情報 ===
+# YAMAPへのログインに使用するメールアドレス、パスワード、および自身のユーザーIDは、
+# このファイル (config.yaml) ではなく、同じディレクトリにある `credentials.yaml` ファイルに記述してください。
+# `credentials.yaml` の例:
+# email: "your_email@example.com"
+# password: "your_password"
+# user_id: "1234567"  # 必ずシングルクォートまたはダブルクォートで囲ってください (数値の場合も)
+
+# これらの設定は、主に `yamap_auto_domo.py` スクリプトから参照され、各自動化機能の動作を制御します。


### PR DESCRIPTION
…g between configurations.

I've introduced a new configuration file, `config_sequential.yaml`, with all parallel processing features disabled. I've also modified the `get_main_config` function in `yamap_auto/driver_utils.py` to allow you to switch between the two configuration files using the `YAMAP_CONFIG_FILE` environment variable.

Additionally, I've updated `cloudbuild.yml` to use the new sequential configuration by default and updated the `README.md` to document the new environment variable.