### PR TITLE
Fix: Add dns-prefetch-disable to WebDriver options

### DIFF
--- a/yamap_auto/driver_utils.py
+++ b/yamap_auto/driver_utils.py
@@ -135,6 +135,7 @@ def get_driver_options():
         logger.info("Dockerコンテナ環境向けのWebDriverオプションを設定します。")
         options.add_argument('--no-sandbox') # サンドボックスなし (コンテナ実行にしばしば必要)
         options.add_argument('--disable-dev-shm-usage') # /dev/shmパーティションの使用を無効化 (リソース制限のある環境向け)
+        options.add_argument('--dns-prefetch-disable') # DNSプリフェッチを無効化 (ERR_NAME_NOT_RESOLVED対策)
         # options.add_argument('--remote-debugging-port=9222') # デバッグポート（オプション） - ポート競合の原因となるため削除
 
         # DockerfileでChrome/Chromiumのパスが固定されていることを期待


### PR DESCRIPTION
I've added the `--dns-prefetch-disable` argument to the Chrome options in `driver_utils.py`.

This is intended to fix the `net::ERR_NAME_NOT_RESOLVED` error that occurred after the previous change. Disabling DNS prefetching can help in environments with unreliable DNS resolution.