### PR TITLE
Hotfix: Import 're' module in my_post_interaction_utils

### DIFF
--- a/yamap_auto/my_post_interaction_utils.py
+++ b/yamap_auto/my_post_interaction_utils.py
@@ -5,6 +5,7 @@
 import time
 import logging
 from datetime import datetime, timedelta
+import re
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait


### PR DESCRIPTION
This commit fixes a `NameError` that occurred because the `re` module was used for date parsing in the `get_my_activities_within_period` function without being imported first.

The missing `import re` statement is added to the top of the file, resolving the runtime error.