### PR TITLE
feat(domo): タイムラインDOMOを個別ページ訪問方式にリファクタリング

### DIFF
--- a/yamap_auto/domo_utils.py
+++ b/yamap_auto/domo_utils.py
@@ -26,84 +26,11 @@ except Exception as e:
     main_config = {}
     TIMELINE_DOMO_SETTINGS = {}
 
-def _domo_an_activity(driver, feed_item_element):
-    """
-    タイムラインの単一フィードアイテム上で直接DOMOを実行します。
-    `domo_activity`から堅牢なセレクタとクリック方法を移植。
-    """
-    activity_id_for_log = "N/A"
-    try:
-        # activity_idの取得はベストエフォート
-        link_element = feed_item_element.find_element(By.CSS_SELECTOR, "a[href*='/activities/']")
-        activity_url = link_element.get_attribute("href")
-        if activity_url and "/activities/" in activity_url:
-            activity_id_for_log = activity_url.split('/')[-1]
-    except NoSuchElementException:
-        pass
-
-    log_prefix = f"[DOMO_ACTION][{activity_id_for_log}]"
-
-    # 1. Check if already reacted
-    try:
-        # `viewer-has-reacted`を持つボタンがあれば、何らかのリアクションが既にある
-        feed_item_element.find_element(By.CSS_SELECTOR, "button.viewer-has-reacted")
-        logger.info(f"{log_prefix} 既にリアクション済みのためスキップします。")
-        return False
-    except NoSuchElementException:
-        # Not reacted, can proceed
-        pass
-
-    # 2. Click the 'add emoji' button and then the 'DOMO' button
-    try:
-        # セレクタを `domo_activity` に合わせてより堅牢なものに変更
-        add_emoji_button_selector = "button[aria-label='絵文字をおくる']"
-        add_emoji_button = feed_item_element.find_element(By.CSS_SELECTOR, add_emoji_button_selector)
-
-        # クリックはJSで行う方が安定する場合がある
-        driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", add_emoji_button)
-        time.sleep(0.5) # scroll後の安定待ち
-        driver.execute_script("arguments[0].click();", add_emoji_button)
-        logger.info(f"{log_prefix} 絵文字追加ボタン(+)を(JSで)クリックしました。")
-
-        # Wait for the DOMO button to appear in the picker and click it
-        # セレクタを `data-emoji-key` に変更
-        domo_emoji_selector = "button[data-emoji-key='domo']"
-        domo_emoji = WebDriverWait(driver, 5).until(
-            EC.element_to_be_clickable((By.CSS_SELECTOR, domo_emoji_selector))
-        )
-
-        # クリック方法を `ActionChains` に変更
-        ActionChains(driver).move_to_element(domo_emoji).click().perform()
-        logger.info(f"{log_prefix} DOMOボタンをクリックしました。")
-
-        # 3. Verify success by waiting for the reacted button to appear
-        # 成功確認のステップを追加
-        WebDriverWait(driver, 5).until(
-            EC.presence_of_element_located((By.CSS_SELECTOR, "button.emoji-button.viewer-has-reacted"))
-        )
-        logger.info(f"{log_prefix} DOMO成功を確認。")
-        return True
-
-    except (NoSuchElementException, TimeoutException) as e:
-        logger.warning(f"{log_prefix} DOMO処理に失敗しました。ボタンが見つからないかタイムアウトしました。詳細: {type(e).__name__}")
-        save_screenshot(driver, "DOMO_TimelineFail", activity_id_for_log)
-        # Try to close any lingering emoji picker by clicking the body
-        try:
-            driver.find_element(By.TAG_NAME, 'body').click()
-        except Exception as e_click_body:
-            logger.debug(f"{log_prefix} DOMO失敗後のリカバリクリックでエラー: {e_click_body}")
-        return False
-    except Exception as e:
-        logger.error(f"{log_prefix} 予期せぬエラー: {e}", exc_info=True)
-        save_screenshot(driver, "DOMO_TimelineError", activity_id_for_log)
-        return False
-
 def domo_timeline_activities(driver):
     """
-    タイムライン上の活動記録にDOMOする機能（逐次処理版）。
-    DOMの変更に強い方法で、タイムライン上の活動に順次DOMOします。
+    タイムライン上の活動記録にDOMOします。各活動記録ページに直接アクセスする方式。
     """
-    logger.info(">>> タイムラインDOMO機能を開始します...")
+    logger.info(">>> タイムラインDOMO機能を開始します (個別ページ訪問方式)...")
     driver.get(TIMELINE_URL)
 
     max_domo = TIMELINE_DOMO_SETTINGS.get("max_activities_to_domo_on_timeline", 5)
@@ -111,65 +38,47 @@ def domo_timeline_activities(driver):
 
     try:
         WebDriverWait(driver, 20).until(
-            EC.presence_of_all_elements_located((By.CSS_SELECTOR, "li.TimelineList__Feed"))
+            EC.presence_of_all_elements_located((By.CSS_SELECTOR, "li.TimelineList__Feed a[href*='/activities/']"))
         )
         logger.info("タイムラインのフィードアイテム群を発見。")
         time.sleep(TIMELINE_DOMO_SETTINGS.get("wait_after_feed_load_sec", 2.0))
 
         # 1. Collect all unique activity URLs first.
         activity_urls = []
-        feed_items = driver.find_elements(By.CSS_SELECTOR, "li.TimelineList__Feed")
-        for item in feed_items:
+        # より具体的なセレクタに変更して、コメントやリアクションのリンクを除外
+        feed_links = driver.find_elements(By.CSS_SELECTOR, "div.TimelineActivityItem__Body > a.TimelineActivityItem__BodyLink[href*='/activities/']")
+        for link in feed_links:
             try:
-                activity_link_element = item.find_element(By.CSS_SELECTOR, "a[href*='/activities/']")
-                url = activity_link_element.get_attribute('href')
+                url = link.get_attribute('href')
                 if url and url not in activity_urls:
                     activity_urls.append(url)
-            except NoSuchElementException:
-                logger.debug("活動記録ではないフィードアイテムをスキップします。")
+            except StaleElementReferenceException:
+                logger.warning("URL収集中にStaleElementReferenceExceptionが発生しました。スキップします。")
                 continue
 
-        logger.info(f"タイムラインから {len(activity_urls)} 件のユニークな活動記録URLを検出しました。")
+        unique_urls = sorted(list(set(activity_urls)))
+        logger.info(f"タイムラインから {len(unique_urls)} 件のユニークな活動記録URLを検出しました。")
 
-        # 2. Iterate over the collected URLs.
-        for i, activity_url in enumerate(activity_urls):
+        # 2. Iterate over the collected URLs and visit each page.
+        for i, activity_url in enumerate(unique_urls):
             if domoed_count >= max_domo:
                 logger.info(f"DOMOの上限 ({max_domo}件) に達しました。")
                 break
 
             activity_id = activity_url.split('/')[-1]
-            logger.info(f"処理中 ({i+1}/{len(activity_urls)}): activity_id={activity_id}")
+            logger.info(f"処理中 ({i+1}/{len(unique_urls)}): activity_id={activity_id}")
 
-            try:
-                # 3. Find the feed item again using a partial href match for robustness.
-                link_selector = f"a[href*='/{activity_id}']"
+            # The existing domo_activity function will be called here.
+            # I will refine it in the next step.
+            if domo_activity(driver, activity_url):
+                domoed_count += 1
 
-                activity_link_element = WebDriverWait(driver, 10).until(
-                    EC.presence_of_element_located((By.CSS_SELECTOR, link_selector))
-                )
-
-                driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", activity_link_element)
-                time.sleep(1)
-
-                feed_item = activity_link_element.find_element(By.XPATH, "./ancestor::li[contains(@class, 'TimelineList__Feed')]")
-
-                if _domo_an_activity(driver, feed_item):
-                    domoed_count += 1
-
-                time.sleep(TIMELINE_DOMO_SETTINGS.get("delay_between_item_processing_sec", 0.5))
-
-            except (NoSuchElementException, TimeoutException):
-                logger.warning(f"ID {activity_id} のフィードアイテムが見つからないか、タイムアウトしました。スキップします。")
-                continue
-            except StaleElementReferenceException:
-                logger.warning(f"ID {activity_id} の処理中に予期せぬ StaleElementReferenceException が発生しました。スキップします。")
-                continue
-            except Exception as e:
-                logger.error(f"ID {activity_id} の処理中に予期せぬエラー: {e}", exc_info=True)
-                continue
+            # Use a reasonable delay between processing items
+            time.sleep(TIMELINE_DOMO_SETTINGS.get("delay_between_item_processing_sec", 1.5))
 
     except TimeoutException:
         logger.warning("タイムライン活動記録の読み込みでタイムアウトしました。")
+        save_screenshot(driver, "DomoTimeline_LoadTimeout")
     except Exception as e:
         logger.error(f"タイムラインDOMO処理中に予期せぬエラーが発生しました。", exc_info=True)
         save_screenshot(driver, "DomoTimeline_FatalError")
@@ -180,7 +89,7 @@ def domo_timeline_activities(driver):
 def domo_activity(driver, activity_url, base_url_for_log=None):
     """
     指定された活動記録URLのページに直接アクセスし、DOMOを実行します。
-    この関数は search_utils など、特定の活動にDOMOしたい場合に使用されます。
+    (堅牢性を向上させるためにリファクタリング)
     """
     activity_id_for_log = activity_url.split('/')[-1] if activity_url else "N/A"
     log_prefix = f"[DOMO_PAGE][{activity_id_for_log}]"
@@ -190,94 +99,54 @@ def domo_activity(driver, activity_url, base_url_for_log=None):
         logger.error(f"{log_prefix} activity_urlが提供されませんでした。")
         return False
 
-    current_url = driver.current_url
-    if activity_url not in current_url:
-        logger.info(f"{log_prefix} ページ ({activity_url}) へ遷移します。")
-        driver.get(activity_url)
-        try:
-            # ページ読み込み待機：より堅牢なセレクタに変更
-            # 1. 主要なコンテナが表示されるのを待つ
-            # 2. その後、インタラクション対象のボタンが表示されるのを待つ
+    try:
+        # Navigate if necessary
+        if activity_url not in driver.current_url:
+            logger.info(f"{log_prefix} ページ ({activity_url}) へ遷移します。")
+            driver.get(activity_url)
             WebDriverWait(driver, 25).until(
                 EC.presence_of_element_located((By.CSS_SELECTOR, "div.ActivityDetailTabLayout, [data-testid='activity-detail-layout']"))
             )
             logger.info(f"{log_prefix} 主要コンテナの表示を確認。")
 
-            # 絵文字ボタンが表示されるまで追加で待機
-            # ユーザー提供HTML: <button ... aria-label="絵文字をおくる" class="... emoji-add-button ...">
-            add_emoji_button_selector = "button[aria-label='絵文字をおくる']"
-            WebDriverWait(driver, 15).until(
-                EC.element_to_be_clickable((By.CSS_SELECTOR, add_emoji_button_selector))
-            )
-            logger.info(f"{log_prefix} 絵文字追加ボタンのクリック準備完了。ページ読み込み完了と判断。")
-
-        except TimeoutException:
-            logger.error(f"{log_prefix} ページ読み込みまたは絵文字ボタン表示タイムアウト。")
-            save_screenshot(driver, "DOMO_PageLoadOrButtonTimeout", activity_id_for_log)
-            return False
-
-    try:
-        # 1. 既にリアクション済みか確認 (セレクタを更新)
+        # Check if already reacted
         try:
-            # リアクションするとボタンの data-testid が変わる可能性がある。より汎用的なセレクタで確認。
             driver.find_element(By.CSS_SELECTOR, "button[data-testid='viewer-reaction-button']")
             logger.info(f"{log_prefix} 既にリアクション済みのためスキップします。")
             return False
         except NoSuchElementException:
-            pass # OK
+            pass # Not reacted yet, proceed.
 
-        # 2. 絵文字追加ボタン(+)をクリック
-        # ページ読み込み待機でセレクタは検証済みなので、ここでは確定で探しに行く
+        # Click the 'add emoji' button
         add_emoji_button_selector = "button[aria-label='絵文字をおくる']"
-        try:
-            add_emoji_button = driver.find_element(By.CSS_SELECTOR, add_emoji_button_selector)
-            # クリック前に画面内にスクロール
-            driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", add_emoji_button)
-            time.sleep(0.7) # スクロール後の安定待ち
-            add_emoji_button.click()
-        except NoSuchElementException:
-             # このエラーは発生しづらいはずだが、念のため
-            logger.error(f"{log_prefix} 絵文字追加ボタン({add_emoji_button_selector})が見つかりませんでした。")
-            save_screenshot(driver, "DOMO_AddButtonNotFound_AfterWait", activity_id_for_log)
-            return False
-        logger.info(f"{log_prefix} 絵文字追加ボタン(+)をクリックしました。")
+        add_emoji_button = WebDriverWait(driver, 15).until(
+            EC.element_to_be_clickable((By.CSS_SELECTOR, add_emoji_button_selector))
+        )
+        driver.execute_script("arguments[0].scrollIntoView({block: 'center'});", add_emoji_button)
+        time.sleep(0.5)
+        driver.execute_script("arguments[0].click();", add_emoji_button) # JS click
+        logger.info(f"{log_prefix} 絵文字追加ボタン(+)を(JSで)クリックしました。")
 
-        # 3. DOMO絵文字をクリック
-        # セレクタをより堅牢な data-emoji-key に変更
+        # Click the DOMO emoji in the picker
         domo_emoji_selector = "button[data-emoji-key='domo']"
-        try:
-            domo_emoji = WebDriverWait(driver, 10).until(
-                EC.element_to_be_clickable((By.CSS_SELECTOR, domo_emoji_selector))
-            )
-            # ActionChainsを使用してクリックすることで、通常のclick()が失敗するケースに対応
-            ActionChains(driver).move_to_element(domo_emoji).click().perform()
-        except TimeoutException:
-            logger.error(f"{log_prefix} DOMO絵文字ボタン ({domo_emoji_selector}) の待機タイムアウト。")
-            save_screenshot(driver, "DOMO_EmojiButtonTimeout", activity_id_for_log)
-            # リカバリのため、開いている可能性のあるピッカーを閉じる試み
-            try:
-                # bodyをクリックするか、閉じるボタンを探す
-                driver.find_element(By.CSS_SELECTOR, "body").click()
-            except Exception:
-                pass
-            return False
+        domo_emoji = WebDriverWait(driver, 10).until(
+            EC.element_to_be_clickable((By.CSS_SELECTOR, domo_emoji_selector))
+        )
+        ActionChains(driver).move_to_element(domo_emoji).click().perform() # ActionChains click
         logger.info(f"{log_prefix} DOMOボタンをクリックしました。")
 
-        # 成功したかどうかの確認
-        try:
-            WebDriverWait(driver, 5).until(
-                EC.presence_of_element_located((By.CSS_SELECTOR, "button.emoji-button.viewer-has-reacted"))
-            )
-            logger.info(f"{log_prefix} DOMO成功を確認。")
-            return True
-        except TimeoutException:
-            logger.warning(f"{log_prefix} DOMO後の確認に失敗。成功した可能性はあります。")
-            return False # 確認できなかったのでFalse
+        # Verify success with an increased timeout
+        logger.info(f"{log_prefix} DOMO成功の確認待機を開始... (最大15秒)")
+        WebDriverWait(driver, 15).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, "button.emoji-button.viewer-has-reacted[data-emoji-key='domo']"))
+        )
+        logger.info(f"{log_prefix} DOMO成功を確認。")
+        return True
 
-    except (NoSuchElementException, TimeoutException) as e:
-        logger.error(f"{log_prefix} DOMO処理中にエラーが発生しました: {type(e).__name__}")
+    except Exception as e:
+        logger.warning(f"{log_prefix} DOMO処理中にエラーが発生しました: {type(e).__name__}")
         save_screenshot(driver, "DOMO_ActionFailed", activity_id_for_log)
-        # HTMLも保存する
+        # Try to save HTML for debugging
         try:
             html_source = driver.page_source
             debug_html_dir = "logs/debug_html"
@@ -288,8 +157,4 @@ def domo_activity(driver, activity_url, base_url_for_log=None):
             logger.info(f"{log_prefix} デバッグ用のHTMLを保存しました: {filename}")
         except Exception as e_html:
             logger.error(f"{log_prefix} デバッグ用HTMLの保存に失敗: {e_html}")
-        return False
-    except Exception as e:
-        logger.error(f"{log_prefix} 予期せぬエラー: {e}", exc_info=True)
-        save_screenshot(driver, "DOMO_UnexpectedError", activity_id_for_log)
         return False


### PR DESCRIPTION
タイムラインDOMO機能の安定性を向上させるため、その実装方法を根本的に変更しました。

従来の方法では、動的に変化するタイムラインフィード上で直接DOMO操作を行っていましたが、`StaleElementReferenceException` や `NoSuchElementException` といったエラーが頻発していました。

新しいアプローチ（個別ページ訪問方式）:
1.  まず、タイムラインページから全てのユニークな活動記録URLを収集します。
2.  次に、収集した各URLに個別にアクセスします。
3.  それぞれの活動記録ページでDOMOアクションを実行します。

この方式により、不安定なタイムラインフィードのDOM構造から処理を分離し、各DOMOアクションを独立して安定的に実行できるようになります。

併せて、DOMOアクションを実行する `domo_activity` 関数も、より堅牢なセレクタ、クリック方法、エラーハンドリング（デバッグ用HTML保存など）を持つように改良しました。